### PR TITLE
Ros2 p4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,10 +61,10 @@ set(critics_sources
 
 set(mppic_sources
   src/controller.cpp
+  src/critic_manager.cpp
   src/path_handler.cpp
   src/trajectory_visualizer.cpp
   src/optimizer.cpp
-  src/critic_scorer.cpp
 )
 
 

--- a/README.md
+++ b/README.md
@@ -113,28 +113,26 @@ controller_server:
       temperature: 0.25
       motion_model: "diff"
       visualize: true
-      CriticScorer:
-        critics_type: "float"
-        critics_names: [ "GoalCritic", "GoalAngleCritic", "AngleToGoalCritic", "ReferenceTrajectoryCritic", "ObstaclesCritic" ]
-        GoalCritic:
-          goal_cost_power: 1
-          goal_cost_weight: 15
-        GoalAngleCritic:
-          goal_angle_cost_power: 1
-          goal_angle_cost_weight: 15 
-          threshold_to_consider_goal_angle: 0.20
-        AngleToGoalCritic:
-          angle_to_goal_cost_power: 2
-          angle_to_goal_cost_weight: 2
-        ReferenceTrajectoryCritic:
-          reference_cost_power: 1
-          reference_cost_weight: 5
-        ObstaclesCritic:
-          consider_footprint: true
-          obstacle_cost_power: 1
-          obstacle_cost_weight: 20
-          inflation_cost_scaling_factor: 3.0
-          inflation_radius: 0.75
+      critics_names: [ "GoalCritic", "GoalAngleCritic", "AngleToGoalCritic", "ReferenceTrajectoryCritic", "ObstaclesCritic" ]
+      GoalCritic:
+        goal_cost_power: 1
+        goal_cost_weight: 15
+      GoalAngleCritic:
+        goal_angle_cost_power: 1
+        goal_angle_cost_weight: 15 
+        threshold_to_consider_goal_angle: 0.20
+      AngleToGoalCritic:
+        angle_to_goal_cost_power: 2
+        angle_to_goal_cost_weight: 2
+      ReferenceTrajectoryCritic:
+        reference_cost_power: 1
+        reference_cost_weight: 5
+      ObstaclesCritic:
+        consider_footprint: true
+        obstacle_cost_power: 1
+        obstacle_cost_weight: 20
+        inflation_cost_scaling_factor: 3.0
+        inflation_radius: 0.75
 ```
 
 ## Topics

--- a/include/mppic/critic_manager.hpp
+++ b/include/mppic/critic_manager.hpp
@@ -50,9 +50,6 @@ protected:
   std::string name_;
 
   std::vector<std::string> critics_names_;
-  std::string critics_type_;
-  const std::string base_name_ = "CriticFunction";
-
   std::unique_ptr<pluginlib::ClassLoader<critics::CriticFunction>> loader_;
   std::vector<std::unique_ptr<critics::CriticFunction>> critics_;
 

--- a/include/mppic/critic_manager.hpp
+++ b/include/mppic/critic_manager.hpp
@@ -1,5 +1,5 @@
-#ifndef MPPIC__CRITIC_SCORER_HPP_
-#define MPPIC__CRITIC_SCORER_HPP_
+#ifndef MPPIC__CRITIC_MANAGER_HPP_
+#define MPPIC__CRITIC_MANAGER_HPP_
 
 #include <xtensor/xtensor.hpp>
 #include <pluginlib/class_loader.hpp>
@@ -17,10 +17,10 @@
 namespace mppi
 {
 
-class CriticScorer
+class CriticManager
 {
 public:
-  CriticScorer() = default;
+  CriticManager() = default;
 
   void on_configure(
     rclcpp_lifecycle::LifecycleNode::WeakPtr parent,
@@ -36,7 +36,8 @@ public:
   /**
    * @brief Evaluate cost for each trajectory
    *
-   * @param trajectories: tensor of shape [ ..., ..., 3 ] * where 3 stands for x, y, yaw
+   * @param trajectories: tensor of shape [ ..., ..., 3 ]
+   * where 3 stands for x, y, yaw
    * @return Cost for each trajectory
    */
   xt::xtensor<double, 1> evalTrajectoriesScores(
@@ -60,4 +61,4 @@ protected:
 
 } // namespace mppi
 
-#endif  // MPPIC__CRITIC_SCORER_HPP_
+#endif  // MPPIC__CRITIC_MANAGER_HPP_

--- a/include/mppic/critics/angle_to_goal_critic.hpp
+++ b/include/mppic/critics/angle_to_goal_critic.hpp
@@ -14,16 +14,7 @@ class AngleToGoalCritic : public CriticFunction
 {
 public:
 
-  void initialize() override
-  {
-    auto node = parent_.lock();
-
-    auto getParam = utils::getParamGetter(node, name_);
-    getParam(power_, "angle_to_goal_cost_power", 1);
-    getParam(weight_, "angle_to_goal_cost_weight", 15);
-    RCLCPP_INFO(
-      logger_, "AngleToGoalCritic instantiated with %d power and %f weight.", power_, weight_);
-  }
+  void initialize() override;
 
   /**
    * @brief Evaluate cost related to robot orientation at goal pose
@@ -33,21 +24,7 @@ public:
    */
   virtual void score(
     const geometry_msgs::msg::PoseStamped & robot_pose, const xt::xtensor<double, 3> & trajectories,
-    const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs) override
-  {
-    auto init_yaw = tf2::getYaw(robot_pose.pose.orientation);
-
-    auto goal_x = xt::view(path, -1, 0);
-    auto goal_y = xt::view(path, -1, 1);
-    auto traj_xs = xt::view(trajectories, xt::all(), xt::all(), 0);
-    auto traj_ys = xt::view(trajectories, xt::all(), xt::all(), 1);
-    auto traj_yaws = xt::view(trajectories, xt::all(), xt::all(), 2);
-
-    auto yaws_between_points = atan2(goal_y - traj_ys, goal_x - traj_xs);
-    auto yaws = xt::abs(traj_yaws - yaws_between_points);
-
-    costs += xt::pow(xt::mean(yaws, {1}) * weight_, power_);
-  }
+    const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs) override;
 
 protected:
   unsigned int power_{0};

--- a/include/mppic/critics/approx_reference_trajectory_critic.hpp
+++ b/include/mppic/critics/approx_reference_trajectory_critic.hpp
@@ -15,18 +15,7 @@ class ApproxReferenceTrajectoryCritic : public CriticFunction
 {
 public:
 
-  void initialize() override
-  {
-    auto node = parent_.lock();
-    auto getParam = utils::getParamGetter(node, name_);
-
-    getParam(power_, "reference_cost_power", 1);
-    getParam(weight_, "reference_cost_weight", 15);
-    RCLCPP_INFO(
-      logger_,
-      "ApproxReferenceTrajectoryCritic instantiated with %d power and %f weight.",
-      power_, weight_);
-  }
+  void initialize() override;
 
   /**
    * @brief Evaluate cost related to trajectories path alignment using
@@ -36,17 +25,7 @@ public:
    */
   virtual void score(
     const geometry_msgs::msg::PoseStamped & /*robot_pose*/, const xt::xtensor<double, 3> & trajectories,
-    const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs) override
-  {
-    auto path_points = xt::view(path, xt::all(), xt::range(0, 2));
-    auto trajectories_points_extended =
-      xt::view(trajectories, xt::all(), xt::all(), xt::newaxis(), xt::range(0, 2));
-
-    auto dists = xt::norm_l2(
-      path_points - trajectories_points_extended, {trajectories_points_extended.dimension() - 1});
-    auto && cost = xt::mean(xt::amin(std::move(dists), 1), 1);
-    costs += xt::pow(std::move(cost) * weight_, power_);
-  }
+    const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs) override;
 
 protected:
   unsigned int power_{0};

--- a/include/mppic/critics/goal_angle_critic.hpp
+++ b/include/mppic/critics/goal_angle_critic.hpp
@@ -14,19 +14,7 @@ class GoalAngleCritic : public CriticFunction
 {
 public:
 
-  void initialize() override
-  {
-    auto node = parent_.lock();
-    auto getParam = utils::getParamGetter(node, name_);
-    
-    getParam(power_, "goal_angle_cost_power", 1);
-    getParam(weight_, "goal_angle_cost_weight", 15);
-    getParam(threshold_to_consider_goal_angle_, "threshold_to_consider_goal_angle", 0.30);
-    RCLCPP_INFO(
-      logger_,
-      "GoalAngleCritic instantiated with %d power, %f weight, and %f angular threshold.",
-      power_, weight_, threshold_to_consider_goal_angle_);
-  }
+  void initialize() override;
 
   /**
    * @brief Evaluate cost related to robot orientation at goal pose
@@ -36,22 +24,7 @@ public:
    */
   virtual void score(
     const geometry_msgs::msg::PoseStamped & robot_pose, const xt::xtensor<double, 3> & trajectories,
-    const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs) override
-  {
-    xt::xtensor<double, 1> tensor_pose = {
-      static_cast<double>(robot_pose.pose.position.x), static_cast<double>(robot_pose.pose.position.y)};
-
-    auto path_points = xt::view(path, -1, xt::range(0, 2));
-
-    double points_to_goal_dists = xt::norm_l2(tensor_pose - path_points, {0})();
-
-    if (points_to_goal_dists < threshold_to_consider_goal_angle_) {
-      auto yaws = xt::view(trajectories, xt::all(), xt::all(), 2);
-      auto goal_yaw = xt::view(path, -1, 2);
-
-      costs += xt::pow(xt::mean(xt::abs(yaws - goal_yaw), {1}) * weight_, power_);
-    }
-  }
+    const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs) override;
 
 protected:
   double threshold_to_consider_goal_angle_{0};

--- a/include/mppic/critics/goal_critic.hpp
+++ b/include/mppic/critics/goal_critic.hpp
@@ -15,16 +15,7 @@ class GoalCritic : public CriticFunction
 {
 public:
 
-  void initialize() override
-  {
-    auto node = parent_.lock();
-    auto getParam = utils::getParamGetter(node, name_);
-    
-    getParam(power_, "goal_cost_power", 1);
-    getParam(weight_, "goal_cost_weight", 20);
-    RCLCPP_INFO(
-      logger_, "GoalCritic instantiated with %d power and %f weight.", power_, weight_);
-  }
+  void initialize() override;
 
   /**
    * @brief Evaluate cost related to goal following
@@ -33,19 +24,7 @@ public:
    */
   virtual void score(
     const geometry_msgs::msg::PoseStamped & /*robot_pose*/, const xt::xtensor<double, 3> & trajectories,
-    const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs) override
-  {
-    const auto goal_points = xt::view(path, -1, xt::range(0, 2));
-
-    auto trajectories_end = xt::view(trajectories, xt::all(), -1, xt::range(0, 2));
-
-    auto dim = trajectories_end.dimension() - 1;
-
-    auto && dists_trajectories_end_to_goal =
-      xt::norm_l2(std::move(trajectories_end) - goal_points, {dim});
-
-    costs += xt::pow(std::move(dists_trajectories_end_to_goal) * weight_, power_);
-  }
+    const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs) override;
 
 protected:
   unsigned int power_{0};

--- a/include/mppic/critics/obstacles_critic.hpp
+++ b/include/mppic/critics/obstacles_critic.hpp
@@ -28,16 +28,15 @@ public:
 protected:
   unsigned char costAtPose(const auto & point);
 
-  bool inCollision(unsigned char cost) const;
+  bool inCollision(unsigned char & cost) const;
 
-  bool isFree(unsigned char cost) const;
+  bool isFree(unsigned char & cost) const;
 
-  double toDist(unsigned char cost);
+  double toDist(unsigned char & cost);
 
-  double scoreDistance(double min_dist);
+  double scoreDistance(double & min_dist);
 
-  nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *> collision_checker_{
-    nullptr};
+  nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *> collision_checker_;
 
   bool consider_footprint_{true};
   double inflation_cost_scaling_factor_{0};

--- a/include/mppic/critics/obstacles_critic.hpp
+++ b/include/mppic/critics/obstacles_critic.hpp
@@ -14,26 +14,7 @@ class ObstaclesCritic : public CriticFunction
 {
 public:
 
-  void initialize() override
-  {
-    auto node = parent_.lock();
-    auto getParam = utils::getParamGetter(node, name_);
-    getParam(consider_footprint_, "consider_footprint", true);
-    getParam(power_, "obstacle_cost_power", 1);
-    getParam(weight_, "obstacle_cost_weight", 20);
-    getParam(inflation_cost_scaling_factor_, "inflation_cost_scaling_factor", 3.0);
-    getParam(inflation_radius_, "inflation_radius", 0.75);
-
-    inscribed_radius_ = costmap_ros_->getLayeredCostmap()->getInscribedRadius();
-    collision_checker_.setCostmap(costmap_);
-    RCLCPP_INFO(
-      logger_,
-      "ObstaclesCritic instantiated with %d power and %f weight. "
-      "It is using %f inflation scale and %f inflation radius to compute distances."
-      "Critic will collision check based on %s cost.",
-      power_, weight_, inflation_cost_scaling_factor_,
-      inflation_radius_, consider_footprint_ ? "footprint" : "circular");
-  }
+  void initialize() override;
 
   /**
    * @brief Evaluate cost related to obstacle avoidance
@@ -42,78 +23,18 @@ public:
    */
   virtual void score(
     const geometry_msgs::msg::PoseStamped & /*robot_pose*/, const xt::xtensor<double, 3> & trajectories,
-    const xt::xtensor<double, 2> & /*path*/, xt::xtensor<double, 1> & costs) override
-  {
-    constexpr double collision_cost_value = std::numeric_limits<double>::max() / 2;
-
-
-    enum TrajectoryState : uint8_t { Collision, Inflated, Free };
-
-    for (size_t i = 0; i < trajectories.shape()[0]; ++i) {
-      double min_dist_to_obstacle = std::numeric_limits<double>::max();
-      TrajectoryState state = Free;
-
-      for (size_t j = 0; j < trajectories.shape()[1]; ++j) {
-        auto point = xt::view(trajectories, i, j, xt::all());
-        unsigned char cost = costAtPose(point);
-        if (!isFree(cost)) {
-          if (inCollision(cost)) {
-            state = Collision;
-            break;
-          }
-          state = Inflated;
-          min_dist_to_obstacle = std::min(toDist(cost), min_dist_to_obstacle);
-        }
-      }
-
-      if (state == Inflated) {
-        costs[i] += scoreDistance(min_dist_to_obstacle);
-      } else if (state == Collision) {
-        costs[i] += collision_cost_value;
-      }
-    }
-  }
+    const xt::xtensor<double, 2> & /*path*/, xt::xtensor<double, 1> & costs) override;
 
 protected:
-  unsigned char costAtPose(const auto & point)
-  {
-    unsigned char cost;
+  unsigned char costAtPose(const auto & point);
 
-    if (consider_footprint_) {
-      cost = static_cast<unsigned char>(collision_checker_.footprintCostAtPose(
-        point(0), point(1), point(2), costmap_ros_->getRobotFootprint()));
-    } else {
-      cost = static_cast<unsigned char>(collision_checker_.pointCost(point(0), point(1)));
-    }
+  bool inCollision(unsigned char cost) const;
 
-    return cost;
-  }
+  bool isFree(unsigned char cost) const;
 
-  bool inCollision(unsigned char cost) const
-  {
-    if (costmap_ros_->getLayeredCostmap()->isTrackingUnknown()) {
-      return cost >= nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE &&
-             cost != nav2_costmap_2d::NO_INFORMATION;
-    }
+  double toDist(unsigned char cost);
 
-    return cost >= nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE;
-  }
-
-  bool isFree(unsigned char cost) const { return cost == nav2_costmap_2d::FREE_SPACE; }
-
-  double toDist(unsigned char cost)
-  {
-    return (-1.0 / inflation_cost_scaling_factor_) *
-             std::log(
-               static_cast<double>(cost) /
-               (static_cast<double>(nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE) - 1.0)) +
-           inscribed_radius_;
-  }
-
-  double scoreDistance(double min_dist)
-  {
-    return static_cast<double>(pow((1.01 * inflation_radius_ - min_dist) * weight_, power_));
-  }
+  double scoreDistance(double min_dist);
 
   nav2_costmap_2d::FootprintCollisionChecker<nav2_costmap_2d::Costmap2D *> collision_checker_{
     nullptr};

--- a/include/mppic/critics/reference_trajectory_critic.hpp
+++ b/include/mppic/critics/reference_trajectory_critic.hpp
@@ -12,16 +12,7 @@ class ReferenceTrajectoryCritic : public CriticFunction
 {
 public:
 
-  void initialize() override
-  {
-    auto node = parent_.lock();
-    auto getParam = utils::getParamGetter(node, name_);
-    getParam(power_, "reference_cost_power", 1);
-    getParam(weight_, "reference_cost_weight", 15);
-    RCLCPP_INFO(
-      logger_,
-      "ReferenceTrajectoryCritic instantiated with %d power and %f weight.", power_, weight_);
-  }
+  void initialize() override;
 
   /**
    * @brief Evaluate cost related to trajectories path alignment
@@ -30,19 +21,7 @@ public:
    */
   virtual void score(
     const geometry_msgs::msg::PoseStamped & /*robot_pose*/, const xt::xtensor<double, 3> & trajectories,
-    const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs) override
-
-  {
-    using xt::evaluation_strategy::immediate;
-
-    xt::xtensor<double, 3> dists_path_to_trajectories =
-      utils::distPointsToLineSegments2D(path, trajectories);
-
-    xt::xtensor<double, 1> cost =
-      xt::mean(xt::amin(std::move(dists_path_to_trajectories), 1, immediate), 1, immediate);
-
-    costs += xt::pow(std::move(cost) * weight_, power_);
-  }
+    const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs) override;
 
 protected:
   unsigned int power_{0};

--- a/include/mppic/optimization/motion_model.hpp
+++ b/include/mppic/optimization/motion_model.hpp
@@ -10,7 +10,7 @@ namespace mppi
 
 enum class MotionModel : uint8_t { Omni, DiffDrive, Carlike };
 
-inline bool isHolonomic(MotionModel motion_model)
+inline bool isHolonomic(const MotionModel & motion_model)
 {
   return (motion_model == MotionModel::Omni) ? true : false;
 }

--- a/include/mppic/optimization/motion_model.hpp
+++ b/include/mppic/optimization/motion_model.hpp
@@ -10,7 +10,7 @@ namespace mppi
 
 enum class MotionModel : uint8_t { Omni, DiffDrive, Carlike };
 
-inline bool isHolonomic(const MotionModel & motion_model)
+inline bool isHolonomic(const MotionModel motion_model)
 {
   return (motion_model == MotionModel::Omni) ? true : false;
 }

--- a/include/mppic/optimizer.hpp
+++ b/include/mppic/optimizer.hpp
@@ -45,7 +45,7 @@ protected:
   void reset();
 
   MotionModel getMotionModel() const;
-  void setMotionModel(const MotionModel &);
+  void setMotionModel(const MotionModel);
 
   /**
    *
@@ -99,8 +99,8 @@ protected:
    * @brief Get offseted control from control_sequence_
    *
    */
-  auto getControlFromSequence(const unsigned int & offset);
-  geometry_msgs::msg::TwistStamped getControlFromSequenceAsTwist(const unsigned int & offset, const auto & stamp);
+  auto getControlFromSequence(const unsigned int offset);
+  geometry_msgs::msg::TwistStamped getControlFromSequenceAsTwist(const unsigned int offset, const auto & stamp);
 
   bool isHolonomic() const;
 

--- a/include/mppic/optimizer.hpp
+++ b/include/mppic/optimizer.hpp
@@ -126,7 +126,7 @@ protected:
   optimization::ControlSequence control_sequence_;
   MotionModel motion_model_t_{MotionModel::DiffDrive};
 
-  CriticManager critic_scorer_;
+  CriticManager critic_manager_;
   std::function<model_t> model_;
 
   xt::xtensor<double, 3> generated_trajectories_{};

--- a/include/mppic/optimizer.hpp
+++ b/include/mppic/optimizer.hpp
@@ -34,7 +34,7 @@ public:
     const geometry_msgs::msg::PoseStamped & robot_pose,
     const geometry_msgs::msg::Twist & robot_speed, const nav_msgs::msg::Path & plan);
 
-  xt::xtensor<double, 3> getGeneratedTrajectories() const;
+  xt::xtensor<double, 3> & getGeneratedTrajectories();
 
   xt::xtensor<double, 2> evalTrajectoryFromControlSequence(
     const geometry_msgs::msg::PoseStamped & robot_pose,
@@ -45,7 +45,7 @@ protected:
   void reset();
 
   MotionModel getMotionModel() const;
-  void setMotionModel(MotionModel);
+  void setMotionModel(const MotionModel &);
 
   /**
    *
@@ -95,16 +95,12 @@ protected:
    */
   void updateControlSequence(const xt::xtensor<double, 1> & costs);
 
-  std::vector<geometry_msgs::msg::Point> getOrientedFootprint(
-    const std::array<double, 3> & robot_pose,
-    const std::vector<geometry_msgs::msg::Point> & footprint_spec) const;
-
   /**
    * @brief Get offseted control from control_sequence_
    *
    */
-  auto getControlFromSequence(unsigned int offset);
-  geometry_msgs::msg::TwistStamped getControlFromSequenceAsTwist(unsigned int offset, const auto & stamp);
+  auto getControlFromSequence(const unsigned int & offset);
+  geometry_msgs::msg::TwistStamped getControlFromSequenceAsTwist(const unsigned int & offset, const auto & stamp);
 
   bool isHolonomic() const;
 

--- a/include/mppic/optimizer.hpp
+++ b/include/mppic/optimizer.hpp
@@ -12,7 +12,7 @@
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
 
 #include "mppic/optimization/motion_model.hpp"
-#include "mppic/critic_scorer.hpp"
+#include "mppic/critic_manager.hpp"
 #include "mppic/optimization/tensor_wrappers/control_sequence.hpp"
 #include "mppic/optimization/tensor_wrappers/state.hpp"
 
@@ -130,7 +130,7 @@ protected:
   optimization::ControlSequence control_sequence_;
   MotionModel motion_model_t_{MotionModel::DiffDrive};
 
-  CriticScorer critic_scorer_;
+  CriticManager critic_scorer_;
   std::function<model_t> model_;
 
   xt::xtensor<double, 3> generated_trajectories_{};

--- a/include/mppic/path_handler.hpp
+++ b/include/mppic/path_handler.hpp
@@ -47,7 +47,7 @@ protected:
   transformToGlobalPlanFrame(const geometry_msgs::msg::PoseStamped & pose);
 
   nav_msgs::msg::Path
-  transformPlanPosesToCostmapFrame(PathIterator begin, PathIterator end, const StampType & stamp);
+  transformPlanPosesToCostmapFrame(PathIterator & begin, PathIterator & end, const StampType & stamp);
 
   auto getGlobalPlanConsideringBounds(const geometry_msgs::msg::PoseStamped & global_pose);
 

--- a/include/mppic/path_handler.hpp
+++ b/include/mppic/path_handler.hpp
@@ -47,11 +47,11 @@ protected:
   transformToGlobalPlanFrame(const geometry_msgs::msg::PoseStamped & pose);
 
   nav_msgs::msg::Path
-  transformPlanPosesToCostmapFrame(PathIterator & begin, PathIterator & end, const StampType & stamp);
+  transformPlanPosesToCostmapFrame(PathIterator begin, PathIterator end, const StampType & stamp);
 
   auto getGlobalPlanConsideringBounds(const geometry_msgs::msg::PoseStamped & global_pose);
 
-  void pruneGlobalPlan(const PathIterator & end);
+  void pruneGlobalPlan(const PathIterator end);
 
   std::string name_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_;

--- a/include/mppic/trajectory_visualizer.hpp
+++ b/include/mppic/trajectory_visualizer.hpp
@@ -24,7 +24,7 @@ public:
   void on_deactivate();
 
   void add(const xt::xtensor<double, 2> & trajectory);
-  void add(const xt::xtensor<double, 3> & trajectories, size_t batch_step, size_t time_step);
+  void add(const xt::xtensor<double, 3> & trajectories, const size_t & batch_step, const size_t & time_step);
   void visualize(nav_msgs::msg::Path & plan);
   void reset();
 
@@ -33,11 +33,11 @@ protected:
     int id, const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & scale,
     const std_msgs::msg::ColorRGBA & color, const std::string & frame_id);
 
-  geometry_msgs::msg::Pose createPose(double x, double y, double z);
+  geometry_msgs::msg::Pose createPose(const double & x, const double & y, const double & z);
 
-  geometry_msgs::msg::Vector3 createScale(double x, double y, double z);
+  geometry_msgs::msg::Vector3 createScale(const double & x, const double & y, const double & z);
 
-  std_msgs::msg::ColorRGBA createColor(float r, float g, float b, float a);
+  std_msgs::msg::ColorRGBA createColor(const float & r, const float & g, const float & b, const float & a);
 
   std::string frame_id_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<visualization_msgs::msg::MarkerArray>>

--- a/include/mppic/trajectory_visualizer.hpp
+++ b/include/mppic/trajectory_visualizer.hpp
@@ -24,7 +24,7 @@ public:
   void on_deactivate();
 
   void add(const xt::xtensor<double, 2> & trajectory);
-  void add(const xt::xtensor<double, 3> & trajectories, const size_t & batch_step, const size_t & time_step);
+  void add(const xt::xtensor<double, 3> & trajectories, const size_t batch_step, const size_t time_step);
   void visualize(nav_msgs::msg::Path & plan);
   void reset();
 
@@ -37,7 +37,7 @@ protected:
 
   geometry_msgs::msg::Vector3 createScale(const double & x, const double & y, const double & z);
 
-  std_msgs::msg::ColorRGBA createColor(const float & r, const float & g, const float & b, const float & a);
+  std_msgs::msg::ColorRGBA createColor(const float r, const float g, const float b, const float a);
 
   std::string frame_id_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<visualization_msgs::msg::MarkerArray>>

--- a/include/mppic/utils.hpp
+++ b/include/mppic/utils.hpp
@@ -38,7 +38,7 @@ auto getParamGetter(NodeT node, const std::string & name)
 
 template <typename T, typename H>
 geometry_msgs::msg::TwistStamped toTwistStamped(
-  const T & velocities, const optimization::ControlSequnceIdxes & idx, bool is_holonomic,
+  const T & velocities, const optimization::ControlSequnceIdxes & idx, const bool & is_holonomic,
   const H & header)
 {
   geometry_msgs::msg::TwistStamped twist;
@@ -57,7 +57,7 @@ geometry_msgs::msg::TwistStamped toTwistStamped(
 
 template <typename T, typename S>
 geometry_msgs::msg::TwistStamped toTwistStamped(
-  const T & velocities, optimization::ControlSequnceIdxes idx, bool is_holonomic, const S & stamp,
+  const T & velocities, optimization::ControlSequnceIdxes idx, const bool & is_holonomic, const S & stamp,
   const std::string & frame)
 {
   geometry_msgs::msg::TwistStamped twist;
@@ -90,7 +90,7 @@ inline xt::xtensor<double, 2> toTensor(const nav_msgs::msg::Path & path)
 }
 
 template <typename T>
-auto hypot(const T & p1, const T & p2)
+double hypot(const T & p1, const T & p2)
 {
   double dx = p1.x - p2.x;
   double dy = p1.y - p2.y;
@@ -99,13 +99,13 @@ auto hypot(const T & p1, const T & p2)
 }
 
 template <>
-inline auto hypot(const geometry_msgs::msg::Pose & lhs, const geometry_msgs::msg::Pose & rhs)
+inline double hypot(const geometry_msgs::msg::Pose & lhs, const geometry_msgs::msg::Pose & rhs)
 {
   return hypot(lhs.position, rhs.position);
 }
 
 template <>
-inline auto
+inline double
 hypot(const geometry_msgs::msg::PoseStamped & lhs, const geometry_msgs::msg::PoseStamped & rhs)
 {
   return hypot(lhs.pose, rhs.pose);

--- a/include/mppic/utils.hpp
+++ b/include/mppic/utils.hpp
@@ -73,18 +73,17 @@ geometry_msgs::msg::TwistStamped toTwistStamped(
   return twist;
 }
 
-template <typename T>
-xt::xtensor<T, 2> toTensor(const nav_msgs::msg::Path & path)
+xt::xtensor<double, 2> toTensor(const nav_msgs::msg::Path & path)
 {
   size_t path_size = path.poses.size();
   static constexpr size_t last_dim_size = 3;
 
-  xt::xtensor<T, 2> points = xt::empty<T>({path_size, last_dim_size});
+  xt::xtensor<double, 2> points = xt::empty<double>({path_size, last_dim_size});
 
   for (size_t i = 0; i < path_size; ++i) {
-    points(i, 0) = static_cast<T>(path.poses[i].pose.position.x);
-    points(i, 1) = static_cast<T>(path.poses[i].pose.position.y);
-    points(i, 2) = static_cast<T>(tf2::getYaw(path.poses[i].pose.orientation));
+    points(i, 0) = static_cast<double>(path.poses[i].pose.position.x);
+    points(i, 1) = static_cast<double>(path.poses[i].pose.position.y);
+    points(i, 2) = static_cast<double>(tf2::getYaw(path.poses[i].pose.orientation));
   }
 
   return points;

--- a/include/mppic/utils.hpp
+++ b/include/mppic/utils.hpp
@@ -73,7 +73,7 @@ geometry_msgs::msg::TwistStamped toTwistStamped(
   return twist;
 }
 
-xt::xtensor<double, 2> toTensor(const nav_msgs::msg::Path & path)
+inline xt::xtensor<double, 2> toTensor(const nav_msgs::msg::Path & path)
 {
   size_t path_size = path.poses.size();
   static constexpr size_t last_dim_size = 3;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -19,7 +19,7 @@ void Controller::configure(
 
   // Get high-level controller parameters
   auto getParam = utils::getParamGetter(node, name_);
-  getParam(visualize_, "visualize", true);
+  getParam(visualize_, "visualize", false);
 
   // Configure composed objects
   optimizer_.initialize(parent_, name_, costmap_ros_, NaiveModel);
@@ -51,9 +51,9 @@ geometry_msgs::msg::TwistStamped Controller::computeVelocityCommands(
   const geometry_msgs::msg::PoseStamped & robot_pose, const geometry_msgs::msg::Twist & robot_speed,
   nav2_core::GoalChecker * /*goal_checker*/)
 {
-  geometry_msgs::msg::TwistStamped cmd;
-  nav_msgs::msg::Path transformed_plan = path_handler_.transformPath(robot_pose);
-  cmd = optimizer_.evalControl(robot_pose, robot_speed, transformed_plan);
+  nav_msgs::msg::Path && transformed_plan = path_handler_.transformPath(robot_pose);
+  geometry_msgs::msg::TwistStamped && cmd =
+    optimizer_.evalControl(robot_pose, robot_speed, transformed_plan);
   visualize(robot_pose, robot_speed, transformed_plan);
   return cmd;
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -51,8 +51,8 @@ geometry_msgs::msg::TwistStamped Controller::computeVelocityCommands(
   const geometry_msgs::msg::PoseStamped & robot_pose, const geometry_msgs::msg::Twist & robot_speed,
   nav2_core::GoalChecker * /*goal_checker*/)
 {
-  nav_msgs::msg::Path && transformed_plan = path_handler_.transformPath(robot_pose);
-  geometry_msgs::msg::TwistStamped && cmd =
+  nav_msgs::msg::Path transformed_plan = path_handler_.transformPath(robot_pose);
+  geometry_msgs::msg::TwistStamped cmd =
     optimizer_.evalControl(robot_pose, robot_speed, transformed_plan);
   visualize(robot_pose, robot_speed, transformed_plan);
   return cmd;

--- a/src/critic_manager.cpp
+++ b/src/critic_manager.cpp
@@ -32,7 +32,7 @@ std::string CriticManager::getFullName(const std::string & name)
 void CriticManager::loadCritics()
 {
   loader_ = std::make_unique<pluginlib::ClassLoader<critics::CriticFunction>>(
-    "mppic", getFullName(base_name_));
+    "mppic", "mppi::critics::CriticFunction");
 
   critics_.clear();
   for (auto name : critics_names_) {

--- a/src/critics/angle_to_goal_critic.cpp
+++ b/src/critics/angle_to_goal_critic.cpp
@@ -1,5 +1,39 @@
 #include "mppic/critics/angle_to_goal_critic.hpp"
 
+namespace mppi::critics
+{
+
+void AngleToGoalCritic::initialize()
+{
+  auto node = parent_.lock();
+
+  auto getParam = utils::getParamGetter(node, name_);
+  getParam(power_, "angle_to_goal_cost_power", 1);
+  getParam(weight_, "angle_to_goal_cost_weight", 15);
+  RCLCPP_INFO(
+    logger_, "AngleToGoalCritic instantiated with %d power and %f weight.", power_, weight_);
+}
+
+void AngleToGoalCritic::score(
+const geometry_msgs::msg::PoseStamped & robot_pose, const xt::xtensor<double, 3> & trajectories,
+const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs)
+{
+  auto init_yaw = tf2::getYaw(robot_pose.pose.orientation);
+
+  auto goal_x = xt::view(path, -1, 0);
+  auto goal_y = xt::view(path, -1, 1);
+  auto traj_xs = xt::view(trajectories, xt::all(), xt::all(), 0);
+  auto traj_ys = xt::view(trajectories, xt::all(), xt::all(), 1);
+  auto traj_yaws = xt::view(trajectories, xt::all(), xt::all(), 2);
+
+  auto yaws_between_points = atan2(goal_y - traj_ys, goal_x - traj_xs);
+  auto yaws = xt::abs(traj_yaws - yaws_between_points);
+
+  costs += xt::pow(xt::mean(yaws, {1}) * weight_, power_);
+}
+
+} // namespace mppi::critics
+
 #include <pluginlib/class_list_macros.hpp>
 
 PLUGINLIB_EXPORT_CLASS(mppi::critics::AngleToGoalCritic, mppi::critics::CriticFunction)

--- a/src/critics/approx_reference_trajectory_critic.cpp
+++ b/src/critics/approx_reference_trajectory_critic.cpp
@@ -1,5 +1,37 @@
 #include "mppic/critics/approx_reference_trajectory_critic.hpp"
 
+namespace mppi::critics
+{
+
+void ApproxReferenceTrajectoryCritic::initialize()
+{
+  auto node = parent_.lock();
+  auto getParam = utils::getParamGetter(node, name_);
+
+  getParam(power_, "reference_cost_power", 1);
+  getParam(weight_, "reference_cost_weight", 15);
+  RCLCPP_INFO(
+    logger_,
+    "ApproxReferenceTrajectoryCritic instantiated with %d power and %f weight.",
+    power_, weight_);
+}
+
+void ApproxReferenceTrajectoryCritic::score(
+const geometry_msgs::msg::PoseStamped & /*robot_pose*/, const xt::xtensor<double, 3> & trajectories,
+const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs)
+{
+  auto path_points = xt::view(path, xt::all(), xt::range(0, 2));
+  auto trajectories_points_extended =
+    xt::view(trajectories, xt::all(), xt::all(), xt::newaxis(), xt::range(0, 2));
+
+  auto dists = xt::norm_l2(
+    path_points - trajectories_points_extended, {trajectories_points_extended.dimension() - 1});
+  auto && cost = xt::mean(xt::amin(std::move(dists), 1), 1);
+  costs += xt::pow(std::move(cost) * weight_, power_);
+}
+
+}  // namespace mppi::critics
+
 #include <pluginlib/class_list_macros.hpp>
 
 PLUGINLIB_EXPORT_CLASS(mppi::critics::ApproxReferenceTrajectoryCritic, mppi::critics::CriticFunction)

--- a/src/critics/goal_angle_critic.cpp
+++ b/src/critics/goal_angle_critic.cpp
@@ -1,5 +1,43 @@
 #include "mppic/critics/goal_angle_critic.hpp"
 
+namespace mppi::critics
+{
+
+void GoalAngleCritic::initialize()
+{
+  auto node = parent_.lock();
+  auto getParam = utils::getParamGetter(node, name_);
+  
+  getParam(power_, "goal_angle_cost_power", 1);
+  getParam(weight_, "goal_angle_cost_weight", 15);
+  getParam(threshold_to_consider_goal_angle_, "threshold_to_consider_goal_angle", 0.30);
+  RCLCPP_INFO(
+    logger_,
+    "GoalAngleCritic instantiated with %d power, %f weight, and %f angular threshold.",
+    power_, weight_, threshold_to_consider_goal_angle_);
+}
+
+void GoalAngleCritic::score(
+  const geometry_msgs::msg::PoseStamped & robot_pose, const xt::xtensor<double, 3> & trajectories,
+  const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs)
+{
+  xt::xtensor<double, 1> tensor_pose = {
+    static_cast<double>(robot_pose.pose.position.x), static_cast<double>(robot_pose.pose.position.y)};
+
+  auto path_points = xt::view(path, -1, xt::range(0, 2));
+
+  double points_to_goal_dists = xt::norm_l2(tensor_pose - path_points, {0})();
+
+  if (points_to_goal_dists < threshold_to_consider_goal_angle_) {
+    auto yaws = xt::view(trajectories, xt::all(), xt::all(), 2);
+    auto goal_yaw = xt::view(path, -1, 2);
+
+    costs += xt::pow(xt::mean(xt::abs(yaws - goal_yaw), {1}) * weight_, power_);
+  }
+}
+
+}  // namespace mppi::critics
+
 #include <pluginlib/class_list_macros.hpp>
 
 PLUGINLIB_EXPORT_CLASS(mppi::critics::GoalAngleCritic, mppi::critics::CriticFunction)

--- a/src/critics/goal_critic.cpp
+++ b/src/critics/goal_critic.cpp
@@ -1,5 +1,37 @@
 #include "mppic/critics/goal_critic.hpp"
 
+namespace mppi::critics
+{
+
+void GoalCritic::initialize()
+{
+  auto node = parent_.lock();
+  auto getParam = utils::getParamGetter(node, name_);
+  
+  getParam(power_, "goal_cost_power", 1);
+  getParam(weight_, "goal_cost_weight", 20);
+  RCLCPP_INFO(
+    logger_, "GoalCritic instantiated with %d power and %f weight.", power_, weight_);
+}
+
+void GoalCritic::score(
+  const geometry_msgs::msg::PoseStamped & /*robot_pose*/, const xt::xtensor<double, 3> & trajectories,
+  const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs)
+{
+  const auto goal_points = xt::view(path, -1, xt::range(0, 2));
+
+  auto trajectories_end = xt::view(trajectories, xt::all(), -1, xt::range(0, 2));
+
+  auto dim = trajectories_end.dimension() - 1;
+
+  auto && dists_trajectories_end_to_goal =
+    xt::norm_l2(std::move(trajectories_end) - goal_points, {dim});
+
+  costs += xt::pow(std::move(dists_trajectories_end_to_goal) * weight_, power_);
+}
+
+}  // namespace mppi::critics
+
 #include <pluginlib/class_list_macros.hpp>
 
 PLUGINLIB_EXPORT_CLASS(mppi::critics::GoalCritic, mppi::critics::CriticFunction)

--- a/src/critics/obstacles_critic.cpp
+++ b/src/critics/obstacles_critic.cpp
@@ -72,22 +72,28 @@ unsigned char ObstaclesCritic::costAtPose(const auto & point)
   return cost;
 }
 
-bool ObstaclesCritic::inCollision(unsigned char cost) const
+bool ObstaclesCritic::inCollision(unsigned char & cost) const
 {
-  if (costmap_ros_->getLayeredCostmap()->isTrackingUnknown()) {
-    return cost >= nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE &&
-           cost != nav2_costmap_2d::NO_INFORMATION;
+  unsigned char max_valid_cost;
+  if (consider_footprint_) {
+    max_valid_cost = nav2_costmap_2d::LETHAL_OBSTACLE;
+  } else {
+    max_valid_cost = nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE;
   }
 
-  return cost >= nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE;
+  if (costmap_ros_->getLayeredCostmap()->isTrackingUnknown()) {
+    return cost >= max_valid_cost && cost != nav2_costmap_2d::NO_INFORMATION;
+  }
+
+  return cost >= max_valid_cost;
 }
 
-bool ObstaclesCritic::isFree(unsigned char cost) const
+bool ObstaclesCritic::isFree(unsigned char & cost) const
 {
 	return cost == nav2_costmap_2d::FREE_SPACE;
 }
 
-double ObstaclesCritic::toDist(unsigned char cost)
+double ObstaclesCritic::toDist(unsigned char & cost)
 {
   return (-1.0 / inflation_cost_scaling_factor_) *
            std::log(
@@ -96,7 +102,7 @@ double ObstaclesCritic::toDist(unsigned char cost)
          inscribed_radius_;
 }
 
-double ObstaclesCritic::scoreDistance(double min_dist)
+double ObstaclesCritic::scoreDistance(double & min_dist)
 {
   return static_cast<double>(pow((1.01 * inflation_radius_ - min_dist) * weight_, power_));
 }

--- a/src/critics/obstacles_critic.cpp
+++ b/src/critics/obstacles_critic.cpp
@@ -1,5 +1,108 @@
 #include "mppic/critics/obstacles_critic.hpp"
 
+namespace mppi::critics
+{
+
+void ObstaclesCritic::initialize()
+{
+  auto node = parent_.lock();
+  auto getParam = utils::getParamGetter(node, name_);
+  getParam(consider_footprint_, "consider_footprint", true);
+  getParam(power_, "obstacle_cost_power", 1);
+  getParam(weight_, "obstacle_cost_weight", 20);
+  getParam(inflation_cost_scaling_factor_, "inflation_cost_scaling_factor", 3.0);
+  getParam(inflation_radius_, "inflation_radius", 0.75);
+
+  inscribed_radius_ = costmap_ros_->getLayeredCostmap()->getInscribedRadius();
+  collision_checker_.setCostmap(costmap_);
+  RCLCPP_INFO(
+    logger_,
+    "ObstaclesCritic instantiated with %d power and %f weight. "
+    "It is using %f inflation scale and %f inflation radius to compute distances."
+    "Critic will collision check based on %s cost.",
+    power_, weight_, inflation_cost_scaling_factor_,
+    inflation_radius_, consider_footprint_ ? "footprint" : "circular");
+}
+
+void ObstaclesCritic::score(
+  const geometry_msgs::msg::PoseStamped & /*robot_pose*/, const xt::xtensor<double, 3> & trajectories,
+  const xt::xtensor<double, 2> & /*path*/, xt::xtensor<double, 1> & costs)
+{
+  constexpr double collision_cost_value = std::numeric_limits<double>::max() / 2;
+
+
+  enum TrajectoryState : uint8_t { Collision, Inflated, Free };
+
+  for (size_t i = 0; i < trajectories.shape()[0]; ++i) {
+    double min_dist_to_obstacle = std::numeric_limits<double>::max();
+    TrajectoryState state = Free;
+
+    for (size_t j = 0; j < trajectories.shape()[1]; ++j) {
+      auto point = xt::view(trajectories, i, j, xt::all());
+      unsigned char cost = costAtPose(point);
+      if (!isFree(cost)) {
+        if (inCollision(cost)) {
+          state = Collision;
+          break;
+        }
+        state = Inflated;
+        min_dist_to_obstacle = std::min(toDist(cost), min_dist_to_obstacle);
+      }
+    }
+
+    if (state == Inflated) {
+      costs[i] += scoreDistance(min_dist_to_obstacle);
+    } else if (state == Collision) {
+      costs[i] += collision_cost_value;
+    }
+  }
+}
+
+unsigned char ObstaclesCritic::costAtPose(const auto & point)
+{
+  unsigned char cost;
+
+  if (consider_footprint_) {
+    cost = static_cast<unsigned char>(collision_checker_.footprintCostAtPose(
+      point(0), point(1), point(2), costmap_ros_->getRobotFootprint()));
+  } else {
+    cost = static_cast<unsigned char>(collision_checker_.pointCost(point(0), point(1)));
+  }
+
+  return cost;
+}
+
+bool ObstaclesCritic::inCollision(unsigned char cost) const
+{
+  if (costmap_ros_->getLayeredCostmap()->isTrackingUnknown()) {
+    return cost >= nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE &&
+           cost != nav2_costmap_2d::NO_INFORMATION;
+  }
+
+  return cost >= nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE;
+}
+
+bool ObstaclesCritic::isFree(unsigned char cost) const
+{
+	return cost == nav2_costmap_2d::FREE_SPACE;
+}
+
+double ObstaclesCritic::toDist(unsigned char cost)
+{
+  return (-1.0 / inflation_cost_scaling_factor_) *
+           std::log(
+             static_cast<double>(cost) /
+             (static_cast<double>(nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE) - 1.0)) +
+         inscribed_radius_;
+}
+
+double ObstaclesCritic::scoreDistance(double min_dist)
+{
+  return static_cast<double>(pow((1.01 * inflation_radius_ - min_dist) * weight_, power_));
+}
+
+}  // namespace mppi::critics
+
 #include <pluginlib/class_list_macros.hpp>
 
 PLUGINLIB_EXPORT_CLASS(mppi::critics::ObstaclesCritic, mppi::critics::CriticFunction)

--- a/src/critics/reference_trajectory_critic.cpp
+++ b/src/critics/reference_trajectory_critic.cpp
@@ -1,5 +1,38 @@
 #include "mppic/critics/reference_trajectory_critic.hpp"
 
+namespace mppi::critics
+{
+
+void ReferenceTrajectoryCritic::initialize()
+{
+  auto node = parent_.lock();
+  auto getParam = utils::getParamGetter(node, name_);
+  getParam(power_, "reference_cost_power", 1);
+  getParam(weight_, "reference_cost_weight", 15);
+  RCLCPP_INFO(
+    logger_,
+    "ReferenceTrajectoryCritic instantiated with %d power and %f weight.", power_, weight_);
+}
+
+void ReferenceTrajectoryCritic::score(
+  const geometry_msgs::msg::PoseStamped & /*robot_pose*/,
+  const xt::xtensor<double, 3> & trajectories,
+  const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs)
+
+{
+  using xt::evaluation_strategy::immediate;
+
+  xt::xtensor<double, 3> dists_path_to_trajectories =
+    utils::distPointsToLineSegments2D(path, trajectories);
+
+  xt::xtensor<double, 1> cost =
+    xt::mean(xt::amin(std::move(dists_path_to_trajectories), 1, immediate), 1, immediate);
+
+  costs += xt::pow(std::move(cost) * weight_, power_);
+}
+
+}  // namespace mppi::critics
+
 #include <pluginlib/class_list_macros.hpp>
 
 PLUGINLIB_EXPORT_CLASS(mppi::critics::ReferenceTrajectoryCritic, mppi::critics::CriticFunction)

--- a/src/critics/reference_trajectory_critic.cpp
+++ b/src/critics/reference_trajectory_critic.cpp
@@ -22,7 +22,7 @@ void ReferenceTrajectoryCritic::score(
 {
   using xt::evaluation_strategy::immediate;
 
-  xt::xtensor<double, 3> dists_path_to_trajectories =
+  xt::xtensor<double, 3> && dists_path_to_trajectories =
     utils::distPointsToLineSegments2D(path, trajectories);
 
   xt::xtensor<double, 1> cost =

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -219,14 +219,14 @@ void Optimizer::updateControlSequence(const xt::xtensor<double, 1> & costs)
 }
 
 geometry_msgs::msg::TwistStamped
-Optimizer::getControlFromSequenceAsTwist(const unsigned int & offset, const auto & stamp)
+Optimizer::getControlFromSequenceAsTwist(const unsigned int offset, const auto & stamp)
 {
   return utils::toTwistStamped(
     getControlFromSequence(offset), control_sequence_.idx, isHolonomic(), stamp,
     costmap_ros_->getBaseFrameID());
 }
 
-auto Optimizer::getControlFromSequence(const unsigned int & offset)
+auto Optimizer::getControlFromSequence(const unsigned int offset)
 {
   return xt::view(control_sequence_.data, offset);
 }
@@ -236,7 +236,7 @@ MotionModel Optimizer::getMotionModel() const
   return motion_model_t_;
 }
 
-void Optimizer::setMotionModel(const MotionModel & motion_model)
+void Optimizer::setMotionModel(const MotionModel motion_model)
 {
   motion_model_t_ = motion_model;
   state_.idx.setLayout(motion_model);

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -77,7 +77,7 @@ geometry_msgs::msg::TwistStamped Optimizer::evalControl(
 {
   for (size_t i = 0; i < iteration_count_; ++i) {
     generated_trajectories_ = generateNoisedTrajectories(robot_pose, robot_speed);
-    auto costs = critic_scorer_.evalTrajectoriesScores(generated_trajectories_, plan, robot_pose);
+    auto && costs = critic_scorer_.evalTrajectoriesScores(generated_trajectories_, plan, robot_pose);
     updateControlSequence(costs);
   }
 
@@ -220,14 +220,14 @@ void Optimizer::updateControlSequence(const xt::xtensor<double, 1> & costs)
 }
 
 geometry_msgs::msg::TwistStamped
-Optimizer::getControlFromSequenceAsTwist(unsigned int offset, const auto & stamp)
+Optimizer::getControlFromSequenceAsTwist(const unsigned int & offset, const auto & stamp)
 {
   return utils::toTwistStamped(
     getControlFromSequence(offset), control_sequence_.idx, isHolonomic(), stamp,
     costmap_ros_->getBaseFrameID());
 }
 
-auto Optimizer::getControlFromSequence(unsigned int offset)
+auto Optimizer::getControlFromSequence(const unsigned int & offset)
 {
   return xt::view(control_sequence_.data, offset);
 }
@@ -237,14 +237,14 @@ MotionModel Optimizer::getMotionModel() const
   return motion_model_t_;
 }
 
-void Optimizer::setMotionModel(MotionModel motion_model)
+void Optimizer::setMotionModel(const MotionModel & motion_model)
 {
   motion_model_t_ = motion_model;
   state_.idx.setLayout(motion_model);
   control_sequence_.idx.setLayout(motion_model);
 }
 
-xt::xtensor<double, 3> Optimizer::getGeneratedTrajectories() const
+xt::xtensor<double, 3> & Optimizer::getGeneratedTrajectories()
 {
   return generated_trajectories_;
 }

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -28,8 +28,7 @@ void Optimizer::initialize(
 
   getParams();
 
-  std::string component_name = name_ + ".CriticScorer";
-  critic_scorer_.on_configure(parent_, component_name, costmap_ros_);
+  critic_manager_.on_configure(parent_, name_, costmap_ros_);
 
   reset();
 }
@@ -77,7 +76,7 @@ geometry_msgs::msg::TwistStamped Optimizer::evalControl(
 {
   for (size_t i = 0; i < iteration_count_; ++i) {
     generated_trajectories_ = generateNoisedTrajectories(robot_pose, robot_speed);
-    auto && costs = critic_scorer_.evalTrajectoriesScores(generated_trajectories_, plan, robot_pose);
+    auto && costs = critic_manager_.evalTrajectoriesScores(generated_trajectories_, plan, robot_pose);
     updateControlSequence(costs);
   }
 

--- a/src/path_handler.cpp
+++ b/src/path_handler.cpp
@@ -63,12 +63,12 @@ PathHandler::transformToGlobalPlanFrame(const geometry_msgs::msg::PoseStamped & 
 nav_msgs::msg::Path PathHandler::transformPath(const geometry_msgs::msg::PoseStamped & robot_pose)
 {
   // Find relevent bounds of path to use
-  geometry_msgs::msg::PoseStamped && global_pose = transformToGlobalPlanFrame(robot_pose);
+  geometry_msgs::msg::PoseStamped global_pose = transformToGlobalPlanFrame(robot_pose);
   auto [lower_bound, upper_bound] = getGlobalPlanConsideringBounds(global_pose);
 
   // Transform these bounds into the local costmap frame and prune older points
   const auto & stamp = global_pose.header.stamp;
-  nav_msgs::msg::Path && transformed_plan = transformPlanPosesToCostmapFrame(lower_bound, upper_bound, stamp);
+  nav_msgs::msg::Path transformed_plan = transformPlanPosesToCostmapFrame(lower_bound, upper_bound, stamp);
 
   pruneGlobalPlan(lower_bound);
 

--- a/src/path_handler.cpp
+++ b/src/path_handler.cpp
@@ -63,12 +63,12 @@ PathHandler::transformToGlobalPlanFrame(const geometry_msgs::msg::PoseStamped & 
 nav_msgs::msg::Path PathHandler::transformPath(const geometry_msgs::msg::PoseStamped & robot_pose)
 {
   // Find relevent bounds of path to use
-  geometry_msgs::msg::PoseStamped global_pose = transformToGlobalPlanFrame(robot_pose);
+  geometry_msgs::msg::PoseStamped && global_pose = transformToGlobalPlanFrame(robot_pose);
   auto [lower_bound, upper_bound] = getGlobalPlanConsideringBounds(global_pose);
 
   // Transform these bounds into the local costmap frame and prune older points
   const auto & stamp = global_pose.header.stamp;
-  nav_msgs::msg::Path transformed_plan = transformPlanPosesToCostmapFrame(lower_bound, upper_bound, stamp);
+  nav_msgs::msg::Path && transformed_plan = transformPlanPosesToCostmapFrame(lower_bound, upper_bound, stamp);
 
   pruneGlobalPlan(lower_bound);
 
@@ -106,7 +106,7 @@ double PathHandler::getMaxCostmapDist()
 }
 
 nav_msgs::msg::Path PathHandler::transformPlanPosesToCostmapFrame(
-  PathIterator begin, PathIterator end, const StampType & stamp)
+  PathIterator & begin, PathIterator & end, const StampType & stamp)
 {
   std::string frame = costmap_->getGlobalFrameID();
   auto transformToFrame = [&](const auto & global_plan_pose) {

--- a/src/path_handler.cpp
+++ b/src/path_handler.cpp
@@ -106,7 +106,7 @@ double PathHandler::getMaxCostmapDist()
 }
 
 nav_msgs::msg::Path PathHandler::transformPlanPosesToCostmapFrame(
-  PathIterator & begin, PathIterator & end, const StampType & stamp)
+  PathIterator begin, PathIterator end, const StampType & stamp)
 {
   std::string frame = costmap_->getGlobalFrameID();
   auto transformToFrame = [&](const auto & global_plan_pose) {
@@ -140,7 +140,7 @@ nav_msgs::msg::Path & PathHandler::getPath()
   return global_plan_;
 }
 
-void PathHandler::pruneGlobalPlan(const PathIterator & end)
+void PathHandler::pruneGlobalPlan(const PathIterator end)
 {
   global_plan_.poses.erase(global_plan_.poses.begin(), end);
 }

--- a/src/trajectory_visualizer.cpp
+++ b/src/trajectory_visualizer.cpp
@@ -47,18 +47,19 @@ void TrajectoryVisualizer::add(const xt::xtensor<double, 2> & trajectory)
   for (size_t i = 0; i < size; i++) {
     float red_component = static_cast<float>(i) / static_cast<float>(size);
 
-    auto pose = createPose(trajectory(i, 0), trajectory(i, 1), 0.06);
-    auto scale = i != size - 1 ? createScale(0.03, 0.03, 0.07) : createScale(0.10, 0.10, 0.10);
+    auto && pose = createPose(trajectory(i, 0), trajectory(i, 1), 0.06);
+    auto && scale = i != size - 1 ? createScale(0.03, 0.03, 0.07) : createScale(0.10, 0.10, 0.10);
 
-    auto color = createColor(red_component, 0, 0, 1);
-    auto marker = createMarker(marker_id_++, pose, scale, color, frame_id_);
+    auto && color = createColor(red_component, 0, 0, 1);
+    auto && marker = createMarker(marker_id_++, pose, scale, color, frame_id_);
 
     points_->markers.push_back(marker);
   }
 }
 
-
-void TrajectoryVisualizer::add(const xt::xtensor<double, 3> & trajectories, size_t batch_step, size_t time_step)
+void TrajectoryVisualizer::add(
+  const xt::xtensor<double, 3> & trajectories,
+  const size_t & batch_step, const size_t & time_step)
 {
   if (!trajectories.shape()[0]) {
     return;
@@ -117,7 +118,8 @@ visualization_msgs::msg::Marker TrajectoryVisualizer::createMarker(
   return marker;
 }
 
-geometry_msgs::msg::Pose TrajectoryVisualizer::createPose(double x, double y, double z)
+geometry_msgs::msg::Pose TrajectoryVisualizer::createPose(
+  const double & x, const double & y, const double & z)
 {
   geometry_msgs::msg::Pose pose;
   pose.position.x = x;
@@ -130,7 +132,8 @@ geometry_msgs::msg::Pose TrajectoryVisualizer::createPose(double x, double y, do
   return pose;
 }
 
-geometry_msgs::msg::Vector3 TrajectoryVisualizer::createScale(double x, double y, double z)
+geometry_msgs::msg::Vector3 TrajectoryVisualizer::createScale(
+  const double & x, const double & y, const double & z)
 {
   geometry_msgs::msg::Vector3 scale;
   scale.x = x;
@@ -139,7 +142,8 @@ geometry_msgs::msg::Vector3 TrajectoryVisualizer::createScale(double x, double y
   return scale;
 }
 
-std_msgs::msg::ColorRGBA TrajectoryVisualizer::createColor(float r, float g, float b, float a)
+std_msgs::msg::ColorRGBA TrajectoryVisualizer::createColor(
+  const float & r, const float & g, const float & b, const float & a)
 {
   std_msgs::msg::ColorRGBA color;
   color.r = r;

--- a/src/trajectory_visualizer.cpp
+++ b/src/trajectory_visualizer.cpp
@@ -47,11 +47,11 @@ void TrajectoryVisualizer::add(const xt::xtensor<double, 2> & trajectory)
   for (size_t i = 0; i < size; i++) {
     float red_component = static_cast<float>(i) / static_cast<float>(size);
 
-    auto && pose = createPose(trajectory(i, 0), trajectory(i, 1), 0.06);
-    auto && scale = i != size - 1 ? createScale(0.03, 0.03, 0.07) : createScale(0.10, 0.10, 0.10);
+    auto pose = createPose(trajectory(i, 0), trajectory(i, 1), 0.06);
+    auto scale = i != size - 1 ? createScale(0.03, 0.03, 0.07) : createScale(0.10, 0.10, 0.10);
 
-    auto && color = createColor(red_component, 0, 0, 1);
-    auto && marker = createMarker(marker_id_++, pose, scale, color, frame_id_);
+    auto color = createColor(red_component, 0, 0, 1);
+    auto marker = createMarker(marker_id_++, pose, scale, color, frame_id_);
 
     points_->markers.push_back(marker);
   }
@@ -59,7 +59,7 @@ void TrajectoryVisualizer::add(const xt::xtensor<double, 2> & trajectory)
 
 void TrajectoryVisualizer::add(
   const xt::xtensor<double, 3> & trajectories,
-  const size_t & batch_step, const size_t & time_step)
+  const size_t batch_step, const size_t time_step)
 {
   if (!trajectories.shape()[0]) {
     return;
@@ -143,7 +143,7 @@ geometry_msgs::msg::Vector3 TrajectoryVisualizer::createScale(
 }
 
 std_msgs::msg::ColorRGBA TrajectoryVisualizer::createColor(
-  const float & r, const float & g, const float & b, const float & a)
+  const float r, const float g, const float b, const float a)
 {
   std_msgs::msg::ColorRGBA color;
   color.r = r;

--- a/test/utils/config.hpp
+++ b/test/utils/config.hpp
@@ -16,8 +16,7 @@ void setUpOptimizerParams(
   params_.emplace_back(rclcpp::Parameter(node_name + ".lookahead_dist", lookahead_dist));
   params_.emplace_back(rclcpp::Parameter(node_name + ".motion_model", motion_model));
 
-  std::string critic_scorer_name = node_name + "." + "CriticScorer";
-  params_.emplace_back(rclcpp::Parameter(critic_scorer_name + ".critics_type", "float"));
+  std::string critic_scorer_name = node_name;
   params_.emplace_back(rclcpp::Parameter(
     critic_scorer_name + ".critics_names",
     std::vector<std::string>{


### PR DESCRIPTION
- Fix recent merge conflict issue
- Rename critic scorer to critic manager since also manages the lifecycle of the critics
- Added const references to all API methods possible
- Moved critic function implementions into src
- Fixed `inCollision` for footprint
- I also tried to deploy some `&&` where I think might be appropriate -- please take a look at that and let me know if I did that sensibly. This is my first time running into this. What I did was add them to functions which had returns of non-trivial size (tensors, paths, etc) that were created and thus to be deleted in the method itself on destruction. My understanding is that then it would assign that memory to the caller of the method rather than copying to the memory, e.g.

```
LargeStruct myMethod()
{
  LargeStruct struct; 
  struct.populate();
  return struct;
}

main()
{
  auto && return_no_copy = myMethod();
}
```