### PR TITLE
small cleanup + linting fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@ find_package(xtensor REQUIRED)
 set(dependencies_pkgs
   rclcpp
   nav2_common
-  pluginlib 
-  tf2 
+  pluginlib
+  tf2
   geometry_msgs
   visualization_msgs
-  nav_msgs 
-  nav2_core 
-  nav2_costmap_2d 
+  nav_msgs
+  nav2_core
+  nav2_costmap_2d
   nav2_util
   tf2_geometry_msgs
   tf2_eigen
@@ -26,7 +26,7 @@ endforeach()
 
 nav2_package()
 
-add_library(mppic SHARED 
+add_library(mppic SHARED
   src/controller.cpp
   src/critic_manager.cpp
   src/path_handler.cpp
@@ -34,7 +34,7 @@ add_library(mppic SHARED
   src/optimizer.cpp
 )
 
-add_library(critics SHARED 
+add_library(critics SHARED
   src/critics/approx_reference_trajectory_critic.cpp
   src/critics/reference_trajectory_critic.cpp
   src/critics/goal_angle_critic.cpp

--- a/README.md
+++ b/README.md
@@ -70,10 +70,9 @@ make install
 
 #### CriticScorer params
 
- | Parameter       | Type   | Definition                                                                                                  |
- | --------------- | ------ | ----------------------------------------------------------------------------------------------------------- |
- | critics_type    | string | Type of controller [float, double]                                                                          |
- | critics_names   | string | Critics (plugins) names
+ | Parameter       | Type        | Definition                                                                                                  |
+ | --------------- | ----------- | ----------------------------------------------------------------------------------------------------------- |
+ | critics         | string list | Critics (plugins) names
 
 #### GoalCritic params
  | Parameter       | Type   | Definition                                                                                                  |
@@ -130,7 +129,7 @@ controller_server:
       temperature: 0.25
       motion_model: "DiffDrive"
       visualize: false
-      critics_names: [ "GoalCritic", "GoalAngleCritic", "PathAngleCritic", "ReferenceTrajectoryCritic", "ObstaclesCritic" ]
+      critics: [ "GoalCritic", "GoalAngleCritic", "PathAngleCritic", "ReferenceTrajectoryCritic", "ObstaclesCritic" ]
       GoalCritic:
         goal_cost_power: 1
         goal_cost_weight: 8.0

--- a/include/mppic/controller.hpp
+++ b/include/mppic/controller.hpp
@@ -1,5 +1,9 @@
+// Copyright 2022 FastSense, Samsung Research
 #ifndef MPPIC__CONTROLLER_HPP_
 #define MPPIC__CONTROLLER_HPP_
+
+#include <string>
+#include <memory>
 
 #include "mppic/path_handler.hpp"
 #include "mppic/optimizer.hpp"
@@ -56,6 +60,6 @@ protected:
   double base_x_vel_, base_y_vel_, base_theta_vel_;
 };
 
-} // namespace mppi
+}  // namespace mppi
 
 #endif  // MPPIC__CONTROLLER_HPP_

--- a/include/mppic/critic_function.hpp
+++ b/include/mppic/critic_function.hpp
@@ -1,7 +1,10 @@
+// Copyright 2022 FastSense, Samsung Research
 #ifndef MPPIC__CRITIC_FUNCTION_HPP_
 #define MPPIC__CRITIC_FUNCTION_HPP_
 
 #include <string>
+#include <memory>
+
 #include <xtensor/xtensor.hpp>
 #include <xtensor/xmath.hpp>
 #include <xtensor/xnorm.hpp>
@@ -76,6 +79,6 @@ protected:
   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
 };
 
-} // namespace mppi::critics
+}  // namespace mppi::critics
 
 #endif  // MPPIC__CRITIC_FUNCTION_HPP_

--- a/include/mppic/critic_manager.hpp
+++ b/include/mppic/critic_manager.hpp
@@ -1,5 +1,10 @@
+// Copyright 2022 FastSense, Samsung Research
 #ifndef MPPIC__CRITIC_MANAGER_HPP_
 #define MPPIC__CRITIC_MANAGER_HPP_
+
+#include <string>
+#include <vector>
+#include <memory>
 
 #include <pluginlib/class_loader.hpp>
 #include <xtensor/xtensor.hpp>
@@ -55,6 +60,6 @@ protected:
   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
 };
 
-} // namespace mppi
+}  // namespace mppi
 
-#endif // MPPIC__CRITIC_MANAGER_HPP_
+#endif  // MPPIC__CRITIC_MANAGER_HPP_

--- a/include/mppic/critic_manager.hpp
+++ b/include/mppic/critic_manager.hpp
@@ -48,7 +48,7 @@ protected:
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   std::string name_;
 
-  std::vector<std::string> critics_names_;
+  std::vector<std::string> critic_names_;
   std::unique_ptr<pluginlib::ClassLoader<critics::CriticFunction>> loader_;
   std::vector<std::unique_ptr<critics::CriticFunction>> critics_;
 

--- a/include/mppic/critics/approx_reference_trajectory_critic.hpp
+++ b/include/mppic/critics/approx_reference_trajectory_critic.hpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #pragma once
 
 #include "mppic/critic_function.hpp"
@@ -17,7 +18,7 @@ public:
    *
    * @param costs [out] add reference cost values to this tensor
    */
-  virtual void score(
+  void score(
     const geometry_msgs::msg::PoseStamped & /*robot_pose*/, const xt::xtensor<double,
     3> & trajectories,
     const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs,
@@ -28,4 +29,4 @@ protected:
   double weight_{0};
 };
 
-} // namespace mppi::critics
+}  // namespace mppi::critics

--- a/include/mppic/critics/goal_angle_critic.hpp
+++ b/include/mppic/critics/goal_angle_critic.hpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #pragma once
 
 #include "mppic/critic_function.hpp"
@@ -17,7 +18,7 @@ public:
    *
    * @param costs [out] add goal angle cost values to this tensor
    */
-  virtual void score(
+  void score(
     const geometry_msgs::msg::PoseStamped & robot_pose, const xt::xtensor<double, 3> & trajectories,
     const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs,
     nav2_core::GoalChecker * goal_checker) override;
@@ -28,4 +29,4 @@ protected:
   double weight_{0};
 };
 
-} // namespace mppi::critics
+}  // namespace mppi::critics

--- a/include/mppic/critics/goal_critic.hpp
+++ b/include/mppic/critics/goal_critic.hpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #pragma once
 
 #include "mppic/critic_function.hpp"
@@ -16,7 +17,7 @@ public:
    *
    * @param costs [out] add reference cost values to this tensor
    */
-  virtual void score(
+  void score(
     const geometry_msgs::msg::PoseStamped & /*robot_pose*/, const xt::xtensor<double,
     3> & trajectories,
     const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs,
@@ -27,4 +28,4 @@ protected:
   double weight_{0};
 };
 
-} // namespace mppi::critics
+}  // namespace mppi::critics

--- a/include/mppic/critics/obstacles_critic.hpp
+++ b/include/mppic/critics/obstacles_critic.hpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #pragma once
 
 #include "nav2_costmap_2d/footprint_collision_checker.hpp"
@@ -18,7 +19,7 @@ public:
    *
    * @param costs [out] add obstacle cost values to this tensor
    */
-  virtual void score(
+  void score(
     const geometry_msgs::msg::PoseStamped & /*robot_pose*/,
     const xt::xtensor<double, 3> & trajectories, const xt::xtensor<double, 2> & /*path*/,
     xt::xtensor<double, 1> & costs, nav2_core::GoalChecker * goal_checker) override;
@@ -40,4 +41,4 @@ protected:
   double weight_{0};
 };
 
-} // namespace mppi::critics
+}  // namespace mppi::critics

--- a/include/mppic/critics/path_angle_critic.hpp
+++ b/include/mppic/critics/path_angle_critic.hpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #pragma once
 
 #include "mppic/critic_function.hpp"
@@ -17,7 +18,7 @@ public:
    *
    * @param costs [out] add goal angle cost values to this tensor
    */
-  virtual void score(
+  void score(
     const geometry_msgs::msg::PoseStamped & robot_pose, const xt::xtensor<double, 3> & trajectories,
     const xt::xtensor<double, 2> & path, xt::xtensor<double, 1> & costs,
     nav2_core::GoalChecker * goal_checker) override;
@@ -27,4 +28,4 @@ protected:
   double weight_{0};
 };
 
-} // namespace mppi::critics
+}  // namespace mppi::critics

--- a/include/mppic/critics/reference_trajectory_critic.hpp
+++ b/include/mppic/critics/reference_trajectory_critic.hpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #pragma once
 
 #include "mppic/critic_function.hpp"
@@ -16,7 +17,7 @@ public:
    *
    * @param costs [out] add reference cost values to this tensor
    */
-  virtual void score(
+  void score(
     const geometry_msgs::msg::PoseStamped & /*robot_pose*/,
     const xt::xtensor<double, 3> & trajectories, const xt::xtensor<double, 2> & path,
     xt::xtensor<double, 1> & costs, nav2_core::GoalChecker * goal_checker) override;
@@ -35,4 +36,4 @@ protected:
   double weight_{0};
 };
 
-} // namespace mppi::critics
+}  // namespace mppi::critics

--- a/include/mppic/motion_models.hpp
+++ b/include/mppic/motion_models.hpp
@@ -1,5 +1,6 @@
-#ifndef MPPIC__OPTIMIZATION__MOTION_MODELS_HPP_
-#define MPPIC__OPTIMIZATION__MOTION_MODELS_HPP_
+// Copyright 2022 FastSense, Samsung Research
+#ifndef MPPIC__MOTION_MODELS_HPP_
+#define MPPIC__MOTION_MODELS_HPP_
 
 #include <cstdint>
 
@@ -35,27 +36,27 @@ public:
 class DiffDriveMotionModel : public MotionModel
 {
 public:
-  virtual bool isHolonomic() const override {return false;}
+  bool isHolonomic() const override {return false;}
 };
 
 class OmniMotionModel : public MotionModel
 {
 public:
-  virtual bool isHolonomic() const override {return true;}
+  bool isHolonomic() const override {return true;}
 };
 
 class AckermannMotionModel : public MotionModel
 {
 public:
-  virtual xt::xtensor<double, 2> predict(
+  xt::xtensor<double, 2> predict(
     const xt::xtensor<double, 2> & /*state*/, const optimization::StateIdxes & /*idx*/) override
   {
     throw std::runtime_error("Ackermann motion model not yet implemented");
   }
 
-  virtual bool isHolonomic() const override {return false;}
+  bool isHolonomic() const override {return false;}
 };
 
-} // namespace mppi
+}  // namespace mppi
 
 #endif  // MPPIC__MOTION_MODELS_HPP_

--- a/include/mppic/motion_models.hpp
+++ b/include/mppic/motion_models.hpp
@@ -13,7 +13,7 @@ class MotionModel
 {
 public:
   MotionModel() = default;
-  ~MotionModel() = default;
+  virtual ~MotionModel() = default;
 
   /**
    * @brief Predict velocities for given trajectories the next time step

--- a/include/mppic/optimizer.hpp
+++ b/include/mppic/optimizer.hpp
@@ -1,6 +1,9 @@
+// Copyright 2022 FastSense, Samsung Research
 #ifndef MPPIC__OPTIMIZER_HPP_
 #define MPPIC__OPTIMIZER_HPP_
 
+#include <string>
+#include <memory>
 #include <xtensor/xtensor.hpp>
 #include <xtensor/xview.hpp>
 
@@ -145,6 +148,6 @@ protected:
   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
 };
 
-} // namespace mppi
+}  // namespace mppi
 
-#endif // MPPIC__OPTIMIZER_HPP_
+#endif  // MPPIC__OPTIMIZER_HPP_

--- a/include/mppic/path_handler.hpp
+++ b/include/mppic/path_handler.hpp
@@ -1,5 +1,11 @@
+// Copyright 2022 FastSense, Samsung Research
 #ifndef MPPIC__PATH_HANDLER_HPP_
 #define MPPIC__PATH_HANDLER_HPP_
+
+#include <vector>
+#include <utility>
+#include <string>
+#include <memory>
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "tf2_ros/buffer.h"
@@ -66,6 +72,6 @@ protected:
   double max_robot_pose_search_dist_{0};
   double transform_tolerance_{0};
 };
-} // namespace mppi
+}  // namespace mppi
 
 #endif  // MPPIC__PATH_HANDLER_HPP_

--- a/include/mppic/tensor_wrappers/control_sequence.hpp
+++ b/include/mppic/tensor_wrappers/control_sequence.hpp
@@ -1,5 +1,6 @@
-#ifndef MPPIC__OPTIMIZATION__TENSOR_WRAPPERS__CONTROL_SEQUENCE_HPP_
-#define MPPIC__OPTIMIZATION__TENSOR_WRAPPERS__CONTROL_SEQUENCE_HPP_
+// Copyright 2022 FastSense, Samsung Research
+#ifndef MPPIC__TENSOR_WRAPPERS__CONTROL_SEQUENCE_HPP_
+#define MPPIC__TENSOR_WRAPPERS__CONTROL_SEQUENCE_HPP_
 
 #include <array>
 #include <cstdint>
@@ -57,6 +58,6 @@ struct ControlSequence
   void reset(unsigned int time_steps) {data = xt::zeros<double>({time_steps, idx.dim()});}
 };
 
-} // namespace mppi::optimization
+}  // namespace mppi::optimization
 
-#endif  // MPPIC__OPTIMIZATION__TENSOR_WRAPPERS__CONTROL_SEQUENCE_HPP_
+#endif  // MPPIC__TENSOR_WRAPPERS__CONTROL_SEQUENCE_HPP_

--- a/include/mppic/tensor_wrappers/state.hpp
+++ b/include/mppic/tensor_wrappers/state.hpp
@@ -1,5 +1,6 @@
-#ifndef MPPIC__OPTIMIZATION__TENSOR_WRAPPERS__STATE_HPP_
-#define MPPIC__OPTIMIZATION__TENSOR_WRAPPERS__STATE_HPP_
+// Copyright 2022 FastSense, Samsung Research
+#ifndef MPPIC__TENSOR_WRAPPERS__STATE_HPP_
+#define MPPIC__TENSOR_WRAPPERS__STATE_HPP_
 
 #include <array>
 #include <cstdint>
@@ -182,6 +183,6 @@ struct State
   }
 };
 
-} // namespace mppi::optimization
+}  // namespace mppi::optimization
 
-#endif  // MPPIC__OPTIMIZATION__TENSOR_WRAPPERS__STATE_HPP_
+#endif  // MPPIC__TENSOR_WRAPPERS__STATE_HPP_

--- a/include/mppic/trajectory_visualizer.hpp
+++ b/include/mppic/trajectory_visualizer.hpp
@@ -1,7 +1,9 @@
+// Copyright 2022 FastSense, Samsung Research
 #ifndef MPPIC__TRAJECTORY_VISUALIZER_HPP_
 #define MPPIC__TRAJECTORY_VISUALIZER_HPP_
 
 #include <memory>
+#include <string>
 #include <xtensor/xtensor.hpp>
 
 #include "nav_msgs/msg/path.hpp"
@@ -52,6 +54,6 @@ protected:
   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
 };
 
-} // namespace mppi
+}  // namespace mppi
 
 #endif  // MPPIC__TRAJECTORY_VISUALIZER_HPP_

--- a/include/mppic/utils.hpp
+++ b/include/mppic/utils.hpp
@@ -1,8 +1,11 @@
+// Copyright 2022 FastSense, Samsung Research
 #ifndef MPPIC__UTILS_HPP_
 #define MPPIC__UTILS_HPP_
 
 #include <algorithm>
 #include <chrono>
+#include <string>
+
 #include <xtensor/xarray.hpp>
 #include <xtensor/xnorm.hpp>
 #include <xtensor/xview.hpp>

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,6 @@
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>
-  <depend>python3-conan-pip</depend>
   <depend>std_msgs</depend>
 
   <exec_depend>nav2_bringup</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,7 @@
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>
-  <depend>conan</depend>
+  <depend>python3-conan-pip</depend>
   <depend>std_msgs</depend>
 
   <exec_depend>nav2_bringup</exec_depend>

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #include <stdint.h>
 #include "nav2_costmap_2d/costmap_filters/filter_values.hpp"
 #include "mppic/controller.hpp"
@@ -110,7 +111,7 @@ void Controller::setSpeedLimit(const double & speed_limit, const bool & percenta
   optimizer_.setControlConstraints(constraints);
 }
 
-} // namespace mppi
+}  // namespace mppi
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(mppi::Controller, nav2_core::Controller)

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -54,7 +54,8 @@ void Controller::deactivate()
 }
 
 geometry_msgs::msg::TwistStamped Controller::computeVelocityCommands(
-  const geometry_msgs::msg::PoseStamped & robot_pose, const geometry_msgs::msg::Twist & robot_speed,
+  const geometry_msgs::msg::PoseStamped & robot_pose,
+  const geometry_msgs::msg::Twist & robot_speed,
   nav2_core::GoalChecker * goal_checker)
 {
   nav_msgs::msg::Path transformed_plan = path_handler_.transformPath(robot_pose);
@@ -66,7 +67,8 @@ geometry_msgs::msg::TwistStamped Controller::computeVelocityCommands(
 }
 
 void Controller::visualize(
-  const geometry_msgs::msg::PoseStamped & robot_pose, const geometry_msgs::msg::Twist & robot_speed,
+  const geometry_msgs::msg::PoseStamped & robot_pose,
+  const geometry_msgs::msg::Twist & robot_speed,
   nav_msgs::msg::Path transformed_plan)
 {
   if (!visualize_) {
@@ -78,7 +80,10 @@ void Controller::visualize(
   trajectory_visualizer_.visualize(transformed_plan);
 }
 
-void Controller::setPlan(const nav_msgs::msg::Path & path) {path_handler_.setPath(path);}
+void Controller::setPlan(const nav_msgs::msg::Path & path)
+{
+  path_handler_.setPath(path);
+}
 
 void Controller::setSpeedLimit(const double & speed_limit, const bool & percentage)
 {

--- a/src/critic_manager.cpp
+++ b/src/critic_manager.cpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #include "mppic/critic_manager.hpp"
 
 namespace mppi
@@ -70,4 +71,4 @@ xt::xtensor<double, 1> CriticManager::evalTrajectoriesScores(
   return costs;
 }
 
-} // namespace mppi
+}  // namespace mppi

--- a/src/critic_manager.cpp
+++ b/src/critic_manager.cpp
@@ -21,15 +21,16 @@ void CriticManager::getParams()
 {
   auto node = parent_.lock();
   auto getParam = utils::getParamGetter(node, name_);
-  getParam(critics_names_, "critics_names", std::vector<std::string>{});
+  getParam(critic_names_, "critics", std::vector<std::string>{});
 }
+
 void CriticManager::loadCritics()
 {
   loader_ = std::make_unique<pluginlib::ClassLoader<critics::CriticFunction>>(
     "mppic", "mppi::critics::CriticFunction");
 
   critics_.clear();
-  for (auto name : critics_names_) {
+  for (auto name : critic_names_) {
     std::string fullname = getFullName(name);
     auto instance =
       std::unique_ptr<critics::CriticFunction>(loader_->createUnmanagedInstance(fullname));
@@ -45,7 +46,8 @@ std::string CriticManager::getFullName(const std::string & name)
 }
 
 xt::xtensor<double, 1> CriticManager::evalTrajectoriesScores(
-  const xt::xtensor<double, 3> & trajectories, const nav_msgs::msg::Path & global_plan,
+  const xt::xtensor<double, 3> & trajectories,
+  const nav_msgs::msg::Path & global_plan,
   const geometry_msgs::msg::PoseStamped & robot_pose,
   nav2_core::GoalChecker * goal_checker) const
 {

--- a/src/critics/approx_reference_trajectory_critic.cpp
+++ b/src/critics/approx_reference_trajectory_critic.cpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #include "mppic/critics/approx_reference_trajectory_critic.hpp"
 
 namespace mppi::critics

--- a/src/critics/goal_angle_critic.cpp
+++ b/src/critics/goal_angle_critic.cpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #include "mppic/critics/goal_angle_critic.hpp"
 
 namespace mppi::critics

--- a/src/critics/goal_critic.cpp
+++ b/src/critics/goal_critic.cpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #include "mppic/critics/goal_critic.hpp"
 
 namespace mppi::critics

--- a/src/critics/obstacles_critic.cpp
+++ b/src/critics/obstacles_critic.cpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #include "mppic/critics/obstacles_critic.hpp"
 #include <xtensor/xaxis_slice_iterator.hpp>
 
@@ -90,7 +91,7 @@ double ObstaclesCritic::scoreCost(unsigned char cost_arg)
   return pow(cost * weight_, power_);
 }
 
-} // namespace mppi::critics
+}  // namespace mppi::critics
 
 #include <pluginlib/class_list_macros.hpp>
 

--- a/src/critics/path_angle_critic.cpp
+++ b/src/critics/path_angle_critic.cpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #include "mppic/critics/path_angle_critic.hpp"
 
 namespace mppi::critics
@@ -36,7 +37,7 @@ void PathAngleCritic::score(
   costs += xt::pow(xt::mean(yaws, {1}) * weight_, power_);
 }
 
-} // namespace mppi::critics
+}  // namespace mppi::critics
 
 #include <pluginlib/class_list_macros.hpp>
 

--- a/src/critics/reference_trajectory_critic.cpp
+++ b/src/critics/reference_trajectory_critic.cpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #include "mppic/critics/reference_trajectory_critic.hpp"
 
 #include <xtensor/xfixed.hpp>
@@ -34,7 +35,7 @@ xt::xtensor<double, 1>
 ReferenceTrajectoryCritic::meanDistancesFromTrajectoriesPointsToReferenceSegments(
   const xt::xtensor<double, 3> & trajectories, const xt::xtensor<double, 2> & reference_path)
 {
-  using namespace xt::placeholders;
+  using namespace xt::placeholders;  // NOLINT
 
   size_t trajectories_count = trajectories.shape()[0];
   size_t trajectories_points_count = trajectories.shape()[1];
@@ -57,7 +58,7 @@ ReferenceTrajectoryCritic::meanDistancesFromTrajectoriesPointsToReferenceSegment
              P2_P1_norm_sq(s);
     };
 
-  static constexpr double eps = static_cast<double>(1e-3); // meters
+  static constexpr double eps = static_cast<double>(1e-3);  // meters
   auto segment_short = P2_P1_norm_sq < eps;
   auto evaluate_dist = [&P3](xt::xtensor_fixed<double, xt::xshape<2>> P, size_t t, size_t p) {
       double dx = P(0) - P3(t, p, 0);
@@ -93,7 +94,7 @@ ReferenceTrajectoryCritic::meanDistancesFromTrajectoriesPointsToReferenceSegment
   return distances;
 }
 
-} // namespace mppi::critics
+}  // namespace mppi::critics
 
 #include <pluginlib/class_list_macros.hpp>
 

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -41,7 +41,6 @@ void Optimizer::getParams()
   auto node = parent_.lock();
 
   auto getParam = utils::getParamGetter(node, name_);
-  auto getParentParam = utils::getParamGetter(node, "");
 
   getParam(model_dt_, "model_dt", 0.1);
   getParam(time_steps_, "time_steps", 15);
@@ -56,7 +55,10 @@ void Optimizer::getParams()
   getParam(vy_std_, "vy_std", 0.1);
   getParam(wz_std_, "wz_std", 0.3);
   getParam(control_sequence_shift_offset_, "control_sequence_shift_offset", 1);
-  getParentParam(controller_frequency_, "controller_frequency", 0.0);
+
+  nav2_util::declare_parameter_if_not_declared(
+    node, "controller_frequency", rclcpp::ParameterValue(0.0));
+  node->get_parameter("controller_frequency", controller_frequency_);
 
   std::string motion_model_name;
   getParam(motion_model_name, "motion_model", std::string("DiffDrive"));

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -1,5 +1,4 @@
-#include "mppic/optimizer.hpp"
-
+// Copyright 2022 FastSense, Samsung Research
 #include <limits>
 #include <memory>
 #include <string>
@@ -118,7 +117,7 @@ void Optimizer::shiftControlSequence()
     return;
   }
 
-  using namespace xt::placeholders;
+  using namespace xt::placeholders;  // NOLINT
   xt::view(
     control_sequence_.data,
     xt::range(_, -control_sequence_shift_offset_), xt::all()) =
@@ -194,7 +193,7 @@ void Optimizer::updateInitialStateVelocities(
 
 void Optimizer::propagateStateVelocitiesFromInitials(auto & state) const
 {
-  using namespace xt::placeholders;
+  using namespace xt::placeholders;  // NOLINT
 
   for (size_t i = 0; i < time_steps_ - 1; i++) {
     auto curr_state = xt::view(state.data, xt::all(), i);
@@ -224,7 +223,7 @@ xt::xtensor<double, 2> Optimizer::evalTrajectoryFromControlSequence(
 xt::xtensor<double, 3> Optimizer::integrateStateVelocities(
   const auto & state, const geometry_msgs::msg::PoseStamped & pose) const
 {
-  using namespace xt::placeholders;
+  using namespace xt::placeholders;  // NOLINT
 
   auto w = state.getVelocitiesWZ();
   double initial_yaw = tf2::getYaw(pose.pose.orientation);

--- a/src/path_handler.cpp
+++ b/src/path_handler.cpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #include "mppic/path_handler.hpp"
 
 #include "mppic/utils.hpp"

--- a/src/trajectory_visualizer.cpp
+++ b/src/trajectory_visualizer.cpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #include <memory>
 
 #include "mppic/trajectory_visualizer.hpp"
@@ -146,4 +147,4 @@ std_msgs::msg::ColorRGBA TrajectoryVisualizer::createColor(float r, float g, flo
   return color;
 }
 
-} // namespace mppi
+}  // namespace mppi

--- a/test/controller_test.cpp
+++ b/test/controller_test.cpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #include "gtest/gtest.h"
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist.hpp>

--- a/test/controller_test.cpp
+++ b/test/controller_test.cpp
@@ -52,4 +52,10 @@ TEST(MPPIController, ControllerTest)
   controller.computeVelocityCommands(pose, velocity, {});
 
   EXPECT_NO_THROW(controller.computeVelocityCommands(pose, velocity, {}));
+
+  controller.setSpeedLimit(0.5, true);
+  controller.setSpeedLimit(0.5, false);
+  controller.setSpeedLimit(1.0, true);
+  controller.deactivate();
+  controller.cleanup();
 }

--- a/test/optimizer_test.cpp
+++ b/test/optimizer_test.cpp
@@ -1,3 +1,4 @@
+// Copyright 2022 FastSense, Samsung Research
 #include "gtest/gtest.h"
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist.hpp>
@@ -71,7 +72,7 @@ TEST(MPPIOptimizer, OptimizerTestDiffFootprint)
   printMapWithTrajectoryAndGoal(*costmap, trajectory, goal_point);
 #endif
   EXPECT_TRUE(!inCollision(trajectory, *costmap));
-  EXPECT_TRUE(isGoalReached(trajectory, *costmap, goal_point));
+  EXPECT_FALSE(isGoalReached(trajectory, *costmap, goal_point));
 }
 
 TEST(MPPIOptimizer, OptimizerTestOmniCircle)
@@ -120,5 +121,5 @@ TEST(MPPIOptimizer, OptimizerTestOmniCircle)
   printMapWithTrajectoryAndGoal(*costmap, trajectory, goal_point);
 #endif
   EXPECT_TRUE(!inCollision(trajectory, *costmap));
-  EXPECT_TRUE(isGoalReached(trajectory, *costmap, goal_point));
+  EXPECT_FALSE(isGoalReached(trajectory, *costmap, goal_point));
 }

--- a/test/optimizer_test.cpp
+++ b/test/optimizer_test.cpp
@@ -126,10 +126,9 @@ TEST(MPPIOptimizer, OptimizerTestOmniCircle)
 
 TEST(MPPIOptimizer, AckermannException)
 {
-  mppi::MotionModel * model = new mppi::AckermannMotionModel();
+  mppi::AckermannMotionModel model;
   xt::xtensor<double, 2> in;
   mppi::optimization::StateIdxes idx;
-  EXPECT_FALSE(model->isHolonomic());
-  EXPECT_THROW(model->predict(in, idx), std::runtime_error);
-  delete model;
+  EXPECT_FALSE(model.isHolonomic());
+  EXPECT_THROW(model.predict(in, idx), std::runtime_error);
 }

--- a/test/optimizer_test.cpp
+++ b/test/optimizer_test.cpp
@@ -72,7 +72,7 @@ TEST(MPPIOptimizer, OptimizerTestDiffFootprint)
   printMapWithTrajectoryAndGoal(*costmap, trajectory, goal_point);
 #endif
   EXPECT_TRUE(!inCollision(trajectory, *costmap));
-  EXPECT_FALSE(isGoalReached(trajectory, *costmap, goal_point));
+  EXPECT_TRUE(isGoalReached(trajectory, *costmap, goal_point));
 }
 
 TEST(MPPIOptimizer, OptimizerTestOmniCircle)
@@ -121,5 +121,15 @@ TEST(MPPIOptimizer, OptimizerTestOmniCircle)
   printMapWithTrajectoryAndGoal(*costmap, trajectory, goal_point);
 #endif
   EXPECT_TRUE(!inCollision(trajectory, *costmap));
-  EXPECT_FALSE(isGoalReached(trajectory, *costmap, goal_point));
+  EXPECT_TRUE(isGoalReached(trajectory, *costmap, goal_point));
+}
+
+TEST(MPPIOptimizer, AckermannException)
+{
+  mppi::MotionModel * model = new mppi::AckermannMotionModel();
+  xt::xtensor<double, 2> in;
+  mppi::optimization::StateIdxes idx;
+  EXPECT_FALSE(model->isHolonomic());
+  EXPECT_THROW(model->predict(in, idx), std::runtime_error);
+  delete model;
 }

--- a/test/utils/config.hpp
+++ b/test/utils/config.hpp
@@ -1,4 +1,7 @@
+// Copyright 2022 FastSense, Samsung Research
 #pragma once
+#include <vector>
+#include <string>
 #include <rclcpp/rclcpp.hpp>
 
 struct TestOptimizerSettings
@@ -58,10 +61,12 @@ void setUpOptimizerParams(
   bool /*consider_footprint*/, std::vector<rclcpp::Parameter> & params_,
   std::string node_name = std::string("dummy"))
 {
+  double dummy_freq = 10.0;
   params_.emplace_back(rclcpp::Parameter(node_name + ".iteration_count", iter));
   params_.emplace_back(rclcpp::Parameter(node_name + ".time_steps", time_steps));
   params_.emplace_back(rclcpp::Parameter(node_name + ".lookahead_dist", lookahead_dist));
   params_.emplace_back(rclcpp::Parameter(node_name + ".motion_model", motion_model));
+  params_.emplace_back(rclcpp::Parameter("controller_frequency", dummy_freq));
 
   std::string critic_scorer_name = node_name;
   params_.emplace_back(
@@ -75,5 +80,7 @@ void setUpControllerParams(
   bool visualize, std::vector<rclcpp::Parameter> & params_,
   std::string node_name = std::string("dummy"))
 {
+  double dummy_freq = 10.0;
   params_.emplace_back(rclcpp::Parameter(node_name + ".visualize", visualize));
+  params_.emplace_back(rclcpp::Parameter("controller_frequency", dummy_freq));
 }

--- a/test/utils/config.hpp
+++ b/test/utils/config.hpp
@@ -71,7 +71,7 @@ void setUpOptimizerParams(
   std::string critic_scorer_name = node_name;
   params_.emplace_back(
     rclcpp::Parameter(
-      critic_scorer_name + ".critics_names",
+      critic_scorer_name + ".critics",
       std::vector<std::string>{
     "GoalCritic", "GoalAngleCritic", "ReferenceTrajectoryCritic", "ObstaclesCritic"}));
 }

--- a/test/utils/factory.hpp
+++ b/test/utils/factory.hpp
@@ -1,6 +1,9 @@
+// Copyright 2022 FastSense, Samsung Research
 #pragma once
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "nav2_costmap_2d/costmap_2d.hpp"
 #include "nav2_costmap_2d/costmap_2d_ros.hpp"
@@ -25,7 +28,7 @@ auto setHeader(auto && msg, auto node, std::string frame)
   msg.header.frame_id = frame;
   msg.header.stamp = time;
 }
-} // namespace detail
+}  // namespace detail
 
 rclcpp::NodeOptions getOptimizerOptions(TestOptimizerSettings s)
 {
@@ -98,7 +101,6 @@ mppi::Optimizer getDummyOptimizer(auto node, auto costmap_ros)
 
 mppi::Controller getDummyController(auto node, auto tf_buffer, auto costmap_ros)
 {
-
   auto controller = mppi::Controller();
   std::weak_ptr<rclcpp_lifecycle::LifecycleNode> weak_ptr_node{node};
 

--- a/test/utils/utils.hpp
+++ b/test/utils/utils.hpp
@@ -1,11 +1,12 @@
+// Copyright 2022 FastSense, Samsung Research
 #pragma once
-
-#include "nav2_costmap_2d/costmap_2d.hpp"
-#include "nav2_costmap_2d/costmap_2d_ros.hpp"
 
 #include <algorithm>
 #include <iostream>
 #include <rclcpp/executors.hpp>
+
+#include "nav2_costmap_2d/costmap_2d.hpp"
+#include "nav2_costmap_2d/costmap_2d_ros.hpp"
 
 #include "config.hpp"
 #include "factory.hpp"
@@ -89,19 +90,19 @@ void print_info(TestOptimizerSettings os, TestPathSettings ps)
 {
   std::cout <<
     "Parameters of MPPI Planner:" <<
-      "Points in path " << ps.poses_count << "\n" <<
-      "Iteration_count " << os.iteration_count << "\n" <<
-      "Time_steps " << os.time_steps << "\n" <<
-      "Motion model " << os.motion_model << "\n"
-      "Is footprint considering " << os.consider_footprint << "\n" << std::endl;
+    "Points in path " << ps.poses_count << "\n" <<
+    "Iteration_count " << os.iteration_count << "\n" <<
+    "Time_steps " << os.time_steps << "\n" <<
+    "Motion model " << os.motion_model << "\n"
+    "Is footprint considering " << os.consider_footprint << "\n" << std::endl;
 }
 
 void print_info(TestOptimizerSettings os, unsigned int poses_count)
 {
   std::cout <<
     "Points in path " << poses_count << "\niteration_count " << os.iteration_count
-                      << "\ntime_steps " << os.time_steps
-                      << "\nMotion model : " << os.motion_model << std::endl;
+            << "\ntime_steps " << os.time_steps
+            << "\nMotion model : " << os.motion_model << std::endl;
 }
 
 void addObstacle(nav2_costmap_2d::Costmap2D * costmap, TestObstaclesSettings s)


### PR DESCRIPTION
Running `colcon test --packages-select mppic` and `colcon test-result --verbose` to find all of the formatting issues for ROS 2 styling and fixes them. 

Also fixes unit tests for `controller_frequency` not set causing an exception for `model_dt` too big

Also added a couple of tests. They're not great, but they at least exercise some of the new functions / fix renaming issues

I fully suspect we'll deviate again and I'll do another linting run before going into Nav2, but its  good to get the bulk done now