### PR TITLE
improves performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ controller_server:
         enabled: true
         cost_power: 1
         cost_weight: 2.0
-        path_point_step: 1
-        trajectory_point_step: 2
+        path_point_step: 2
+        trajectory_point_step: 3
       PathFollowCritic:
         enabled: true
         cost_power: 1

--- a/src/critics/path_align_critic.cpp
+++ b/src/critics/path_align_critic.cpp
@@ -13,8 +13,8 @@ void PathAlignCritic::initialize()
   getParam(power_, "cost_power", 1);
   getParam(weight_, "cost_weight", 2.0);
 
-  getParam(path_point_step_, "path_point_step", 1);
-  getParam(trajectory_point_step_, "trajectory_point_step", 2);
+  getParam(path_point_step_, "path_point_step", 2);
+  getParam(trajectory_point_step_, "trajectory_point_step", 3);
 
   RCLCPP_INFO(
     logger_,

--- a/src/critics/path_align_critic.cpp
+++ b/src/critics/path_align_critic.cpp
@@ -62,7 +62,7 @@ void PathAlignCritic::score(models::CriticFunctionData & data)
       size_t t, size_t p) {
       double dx = P(0) - P3(t, p, 0);
       double dy = P(1) - P3(t, p, 1);
-      return std::hypot(dx, dy);
+      return std::sqrt(dx * dx + dy * dy);
     };
 
 


### PR DESCRIPTION
- Hypot -> sqrt improves behavior by 10%. Puts Path align critic from ~20% to ~11%
- Changed the point/trajectory steps from 1/2 to 2/3. Extends the gains from ~11% to ~6%  --> all of evaluating critics is now a total of 16%. Generating the noised trajectories is now 46% 

Total, these 2 changes get us back about 14% -- which is kind of nuts

This leaves `integrateStateVelocities`'s concatenation at a total of 21% of the total run time (and `integrateStateVelocities` in total is 26%). 

I can't tell exactly where the `46-26=20%` is left under the trajectory generation process, but it points to `generateNoisedControls` as a function, so I'm making an educated guess that the concatenation there is a **big** contributor to it since those numbers are consistent with the overhead in `integrateStateVelocities` and those are the only 2 places that concats are used anywhere in the program. 