### PR TITLE
optimizations in compilation and threading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(critics SHARED
 set(libraries mppic critics)
 
 foreach(lib IN LISTS libraries)
+  target_compile_options(${lib} PUBLIC -fconcepts)
   target_include_directories(${lib} PUBLIC include ${xsimd_INCLUDE_DIRS} ${OpenMP_INCLUDE_DIRS})
   target_link_libraries(${lib} xtensor xtensor::optimize xtensor::use_xsimd)
   ament_target_dependencies(${lib} ${dependencies_pkgs})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(mppic)
 
-set(XTENSOR_USE_XSIMD 1)
-set(XTENSOR_USE_OPENMP 1)
+add_definitions(-DXTENSOR_ENABLE_XSIMD)
+add_definitions(-DXTENSOR_USE_XSIMD)
 
 find_package(ament_cmake REQUIRED)
 find_package(xtensor REQUIRED)
@@ -28,7 +28,7 @@ foreach(pkg IN LISTS dependencies_pkgs)
 endforeach()
 
 nav2_package()
-add_compile_options(-O3 -mavx2 -mfma -finline-limit=1000000 -ffp-contract=fast)
+add_compile_options(-O3 -mavx2 -mfma -finline-limit=1000000 -ffp-contract=fast -march=native -ffast-math)
 
 add_library(mppic SHARED
   src/controller.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(mppic SHARED
   src/trajectory_visualizer.cpp
   src/path_handler.cpp
   src/parameters_handler.cpp
+  src/noise_generator.cpp
 )
 
 add_library(critics SHARED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,13 @@ foreach(pkg IN LISTS dependencies_pkgs)
 endforeach()
 
 nav2_package()
+add_compile_options(-O3 -mavx2 -mfma -finline-limit=1000000 -ffp-contract=fast)
+
+include_directories(
+  include
+  ${xsimd_INCLUDE_DIRS}
+  ${OpenMP_INCLUDE_DIRS}
+)
 
 add_library(mppic SHARED
   src/controller.cpp
@@ -52,8 +59,6 @@ add_library(critics SHARED
 set(libraries mppic critics)
 
 foreach(lib IN LISTS libraries)
-  target_compile_options(${lib} PUBLIC -fconcepts)
-  target_include_directories(${lib} PUBLIC include)
   target_link_libraries(${lib} xtensor xtensor::optimize xtensor::use_xsimd)
   ament_target_dependencies(${lib} ${dependencies_pkgs})
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,15 +60,6 @@ foreach(lib IN LISTS libraries)
   ament_target_dependencies(${lib} ${dependencies_pkgs})
 endforeach()
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  find_package(ament_cmake_gtest REQUIRED)
-  set(ament_cmake_copyright_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-  add_subdirectory(test)
-  add_subdirectory(benchmark)
-endif()
-
 install(TARGETS mppic critics
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -78,6 +69,15 @@ install(TARGETS mppic critics
 install(DIRECTORY include/
   DESTINATION include/
 )
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+  add_subdirectory(test)
+  add_subdirectory(benchmark)
+endif()
 
 ament_export_libraries(${libraries})
 ament_export_dependencies(${dependencies_pkgs})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,6 @@ endforeach()
 nav2_package()
 add_compile_options(-O3 -mavx2 -mfma -finline-limit=1000000 -ffp-contract=fast)
 
-include_directories(
-  include
-  ${xsimd_INCLUDE_DIRS}
-  ${OpenMP_INCLUDE_DIRS}
-)
-
 add_library(mppic SHARED
   src/controller.cpp
   src/optimizer.cpp
@@ -60,9 +54,19 @@ add_library(critics SHARED
 set(libraries mppic critics)
 
 foreach(lib IN LISTS libraries)
+  target_include_directories(${lib} PUBLIC include ${xsimd_INCLUDE_DIRS} ${OpenMP_INCLUDE_DIRS})
   target_link_libraries(${lib} xtensor xtensor::optimize xtensor::use_xsimd)
   ament_target_dependencies(${lib} ${dependencies_pkgs})
 endforeach()
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+  add_subdirectory(test)
+  add_subdirectory(benchmark)
+endif()
 
 install(TARGETS mppic critics
   ARCHIVE DESTINATION lib
@@ -73,15 +77,6 @@ install(TARGETS mppic critics
 install(DIRECTORY include/
   DESTINATION include/
 )
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  find_package(ament_cmake_gtest REQUIRED)
-  set(ament_cmake_copyright_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-  add_subdirectory(test)
-  add_subdirectory(benchmark)
-endif()
 
 ament_export_libraries(${libraries})
 ament_export_dependencies(${dependencies_pkgs})

--- a/benchmark/controller_benchmark.cpp
+++ b/benchmark/controller_benchmark.cpp
@@ -96,12 +96,12 @@ void prepareAndRunBenchmark(
   auto velocity = getDummyTwist();
   auto path = getIncrementalDummyPath(node, path_settings);
 
-  controller.setPlan(path);
+  controller->setPlan(path);
 
   nav2_core::GoalChecker * dummy_goal_checker{nullptr};
 
   for (auto _ : state) {
-    controller.computeVelocityCommands(pose, velocity, dummy_goal_checker);
+    controller->computeVelocityCommands(pose, velocity, dummy_goal_checker);
   }
   map_odom_broadcaster.wait();
   odom_base_link_broadcaster.wait();

--- a/benchmark/optimizer_benchmark.cpp
+++ b/benchmark/optimizer_benchmark.cpp
@@ -77,7 +77,7 @@ void prepareAndRunBenchmark(
   nav2_core::GoalChecker * dummy_goal_checker{nullptr};
 
   for (auto _ : state) {
-    optimizer.evalControl(pose, velocity, path, dummy_goal_checker);
+    optimizer->evalControl(pose, velocity, path, dummy_goal_checker);
   }
 
 }

--- a/include/mppic/optimizer.hpp
+++ b/include/mppic/optimizer.hpp
@@ -106,7 +106,7 @@ protected:
   geometry_msgs::msg::TwistStamped
   getControlFromSequenceAsTwist(const builtin_interfaces::msg::Time & stamp);
 
-  bool isHolonomic() const;
+  inline bool isHolonomic() const;
 
   void setOffset(double controller_frequency);
 

--- a/include/mppic/optimizer.hpp
+++ b/include/mppic/optimizer.hpp
@@ -117,6 +117,8 @@ protected:
 
   bool fallback(bool fail);
 
+  void noiseThread();
+
 protected:
   rclcpp_lifecycle::LifecycleNode::WeakPtr parent_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
@@ -138,11 +140,15 @@ protected:
   xt::xtensor<double, 2> plan_;
   xt::xtensor<double, 1> costs_;
 
-
   CriticData critics_data_ =
   {state_, generated_trajectories_, plan_, costs_, false, nullptr, std::nullopt}; /// Caution, keep references
 
   rclcpp::Logger logger_{rclcpp::get_logger("MPPIController")};
+
+  std::thread noise_thread_;
+  std::condition_variable noise_cond_;
+  std::mutex noise_lock_;
+  bool active_{true}, ready_{false};
 };
 
 }  // namespace mppi

--- a/include/mppic/optimizer.hpp
+++ b/include/mppic/optimizer.hpp
@@ -35,6 +35,8 @@ class Optimizer
 public:
   Optimizer() = default;
 
+  ~Optimizer(){shutdown();}
+
   void initialize(
     rclcpp_lifecycle::LifecycleNode::WeakPtr parent, const std::string & name,
     std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros,

--- a/include/mppic/tools/noise_generator.hpp
+++ b/include/mppic/tools/noise_generator.hpp
@@ -1,0 +1,85 @@
+// Copyright 2022 @artofnothingness Alexey Budyakov, Samsung Research
+
+#ifndef MPPIC__NOISE_GENERATOR_HPP_
+#define MPPIC__NOISE_GENERATOR_HPP_
+
+#include <string>
+#include <memory>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+
+#include <xtensor/xtensor.hpp>
+#include <xtensor/xview.hpp>
+
+#include "mppic/models/optimizer_settings.hpp"
+#include "mppic/models/state.hpp"
+
+namespace mppi
+{
+
+class NoiseGenerator
+{
+public:
+  NoiseGenerator() = default;
+
+  /**
+   * @brief Initialize noise generator with settings and model types
+   * @param settings Settings of controller
+   * @param is_holonomic If base is holonomic
+   */
+  void initialize(mppi::models::OptimizerSettings & settings, bool is_holonomic);
+
+  /**
+   * @brief Shutdown noise generator thread
+   */
+  void shutdown();
+
+  /**
+   * @brief Signal to the noise thread the controller is ready to generate a new
+   * noised control for the next iteration
+   */
+  void generateNextNoises();
+
+  /**
+   * @brief Get the current noises
+   * @return noises Reference to current noises
+   */
+  xt::xtensor<double, 3> & getNoises();
+
+  /**
+   * @brief Reset noise generator with settings and model types
+   * @param settings Settings of controller
+   * @param is_holonomic If base is holonomic
+   */
+  void reset(mppi::models::OptimizerSettings & settings, bool is_holonomic);
+
+protected:
+  /**
+   * @brief Thread to execute noise generation process
+   */
+  void noiseThread();
+
+  /**
+   * @brief Generate random controls by gaussian noise with mean in
+   * control_sequence_
+   *
+   * @return tensor of shape [ batch_size_, time_steps_, 2]
+   * where 2 stands for v, w
+   */
+  void generateNoisedControls();
+
+  xt::xtensor<double, 3> noises_;
+
+  mppi::models::OptimizerSettings settings_;
+  bool is_holonomic_;
+
+  std::thread noise_thread_;
+  std::condition_variable noise_cond_;
+  std::mutex noise_lock_;
+  bool active_{false}, ready_{false};
+};
+
+}  // namespace mppi
+
+#endif  // MPPIC__NOISE_GENERATOR_HPP_

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -34,6 +34,7 @@ void Controller::configure(
 
 void Controller::cleanup()
 {
+  optimizer_.shutdown();
   trajectory_visualizer_.on_cleanup();
   parameters_handler_.reset();
   RCLCPP_INFO(logger_, "Cleaned up MPPI Controller: %s", name_.c_str());

--- a/src/noise_generator.cpp
+++ b/src/noise_generator.cpp
@@ -1,0 +1,84 @@
+// Copyright 2022 @artofnothingness Alexey Budyakov, Samsung Research
+#include "mppic/tools/noise_generator.hpp"
+
+#include <memory>
+#include <mutex>
+#include <xtensor/xmath.hpp>
+#include <xtensor/xrandom.hpp>
+
+namespace mppi
+{
+
+void NoiseGenerator::initialize(mppi::models::OptimizerSettings & settings, bool is_holonomic)
+{
+  settings_ = settings;
+  is_holonomic_ = is_holonomic;
+  active_ = true;
+  noise_thread_ = std::thread(std::bind(&NoiseGenerator::noiseThread, this));
+}
+
+void NoiseGenerator::shutdown()
+{
+  active_ = false;
+  ready_ = true;
+  noise_cond_.notify_all();
+  noise_thread_.join();
+}
+
+void NoiseGenerator::generateNextNoises()
+{
+  // Trigger the thread to run in parallel to this iteration
+  // to generate the next iteration's noises.
+  {
+    std::unique_lock<std::mutex> guard(noise_lock_);
+    ready_ = true;
+  }
+  noise_cond_.notify_all();
+}
+
+xt::xtensor<double, 3> & NoiseGenerator::getNoises()
+{
+  std::unique_lock<std::mutex> guard(noise_lock_);
+  return noises_;
+}
+
+void NoiseGenerator::reset(mppi::models::OptimizerSettings & settings, bool is_holonomic)
+{
+  settings_ = settings;
+  is_holonomic_ = is_holonomic;
+
+  // Recompute the noises on reset, initialization, and fallback
+  {
+    std::unique_lock<std::mutex> guard(noise_lock_);
+    noises_ =
+      xt::zeros<double>({settings_.batch_size, settings_.time_steps, is_holonomic_ ? 3u : 2u});
+    ready_ = true;
+  }
+  noise_cond_.notify_all();
+}
+
+void NoiseGenerator::noiseThread()
+{
+  do {
+    std::unique_lock<std::mutex> guard(noise_lock_);
+    noise_cond_.wait(guard, [this](){return ready_;});
+    ready_ = false;
+    generateNoisedControls();
+  } while (active_);
+}
+
+void NoiseGenerator::generateNoisedControls()
+{
+  auto & s = settings_;
+  auto vx = xt::view(noises_, xt::all(), xt::all(), 0);
+  auto wz = xt::view(noises_, xt::all(), xt::all(), is_holonomic_ ? 2 : 1);
+
+  vx = xt::random::randn<double>({s.batch_size, s.time_steps}, 0.0, s.sampling_std.vx);
+  wz = xt::random::randn<double>({s.batch_size, s.time_steps}, 0.0, s.sampling_std.wz);
+  if (is_holonomic_) {
+    auto vy = xt::view(noises_, xt::all(), xt::all(), 1);
+    vy = xt::random::randn<double>({s.batch_size, s.time_steps}, 0.0, s.sampling_std.vy);
+  }
+}
+
+}  // namespace mppi

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -32,19 +32,14 @@ void Optimizer::initialize(
   getParams();
 
   critic_manager_.on_configure(parent_, name_, costmap_ros_, parameters_handler_);
-  noise_thread_ = std::thread(std::bind(&Optimizer::noiseThread, this)); //TODO join / shutdown
+  noise_generator_.initialize(settings_, isHolonomic());
 
   reset();
 }
 
-void Optimizer::noiseThread()
+void Optimizer::shutdown()
 {
-  do {
-    std::unique_lock<std::mutex> guard(noise_lock_);
-    noise_cond_.wait(guard, [this](){return !active_ || ready_;});
-    ready_ = false;
-    generateNoisedControls();
-  } while (active_);
+  noise_generator_.shutdown();
 }
 
 void Optimizer::getParams()
@@ -107,15 +102,8 @@ void Optimizer::reset()
   control_sequence_.reset(settings_.time_steps);
   costs_ = xt::zeros<double>({settings_.batch_size});
   generated_trajectories_ = xt::zeros<double>({settings_.batch_size, settings_.time_steps, 3u});
-  noises_ =
-    xt::zeros<double>({settings_.batch_size, settings_.time_steps, isHolonomic() ? 3u : 2u});
 
-  // Recompute the noises on reset, initialization, and fallback
-  {
-    std::unique_lock<std::mutex> guard(noise_lock_);
-    ready_ = true;
-  }
-  noise_cond_.notify_all();
+  noise_generator_.reset(settings_, isHolonomic());
   RCLCPP_INFO(logger_, "Optimizer reset");
 }
 
@@ -193,33 +181,11 @@ void Optimizer::shiftControlSequence()
 
 void Optimizer::generateNoisedTrajectories()
 {
-  // Add in the generated noises from the noise generation thread
-  // Then, trigger the thread to run in parallel to this iteration
-  // to generate the next iteration's noises.
-  {
-    std::unique_lock<std::mutex> guard(noise_lock_);
-    state_.getControls() = control_sequence_.data + noises_;
-    ready_ = true;
-  }
-
-  noise_cond_.notify_all();
+  state_.getControls() = control_sequence_.data + noise_generator_.getNoises();
+  noise_generator_.generateNextNoises();
   applyControlConstraints();
   updateStateVelocities(state_);
   integrateStateVelocities(generated_trajectories_, state_);
-}
-
-void Optimizer::generateNoisedControls()
-{
-  auto & s = settings_;
-  auto vx = xt::view(noises_, xt::all(), xt::all(), 0);
-  auto wz = xt::view(noises_, xt::all(), xt::all(), isHolonomic() ? 2 : 1);
-
-  vx = xt::random::randn<double>({s.batch_size, s.time_steps}, 0.0, s.sampling_std.vx);
-  wz = xt::random::randn<double>({s.batch_size, s.time_steps}, 0.0, s.sampling_std.wz);
-  if (isHolonomic()) {
-    auto vy = xt::view(noises_, xt::all(), xt::all(), 1);
-    vy = xt::random::randn<double>({s.batch_size, s.time_steps}, 0.0, s.sampling_std.vy);
-  }
 }
 
 bool Optimizer::isHolonomic() const {return motion_model_->isHolonomic();}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,4 +18,5 @@ foreach(name IN LISTS TEST_NAMES)
   if(${TEST_DEBUG_INFO})
     target_compile_definitions(${name} PUBLIC -DTEST_DEBUG_INFO)
   endif()
+
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,14 +3,15 @@ set(TEST_NAMES
   controller_test
 )
 
-
 foreach(name IN LISTS TEST_NAMES)
   ament_add_gtest(${name}
     ${name}.cpp
   )
+
   ament_target_dependencies(${name}
     ${dependencies_pkgs}
   )
+
   target_link_libraries(${name}
     mppic
   )

--- a/test/controller_test.cpp
+++ b/test/controller_test.cpp
@@ -48,13 +48,13 @@ TEST(ControllerTest, ControllerNotFail)
   auto velocity = getDummyTwist();
   auto path = getIncrementalDummyPath(node, path_settings);
 
-  controller.setPlan(path);
+  controller->setPlan(path);
 
-  EXPECT_NO_THROW(controller.computeVelocityCommands(pose, velocity, {}));
+  EXPECT_NO_THROW(controller->computeVelocityCommands(pose, velocity, {}));
 
-  controller.setSpeedLimit(0.5, true);
-  controller.setSpeedLimit(0.5, false);
-  controller.setSpeedLimit(1.0, true);
-  controller.deactivate();
-  controller.cleanup();
+  controller->setSpeedLimit(0.5, true);
+  controller->setSpeedLimit(0.5, false);
+  controller->setSpeedLimit(1.0, true);
+  controller->deactivate();
+  controller->cleanup();
 }

--- a/test/optimizer_test.cpp
+++ b/test/optimizer_test.cpp
@@ -72,7 +72,7 @@ TEST_P(OptimizerSuite, OptimizerTest) {
   auto path = getIncrementalDummyPath(node, path_settings);
   nav2_core::GoalChecker * dummy_goal_checker{nullptr};
 
-  EXPECT_NO_THROW(optimizer.evalControl(pose, velocity, path, dummy_goal_checker));
+  EXPECT_NO_THROW(optimizer->evalControl(pose, velocity, path, dummy_goal_checker));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/utils/factory.hpp
+++ b/test/utils/factory.hpp
@@ -131,12 +131,12 @@ getDummyNode(rclcpp::NodeOptions options, std::string node_name = std::string("d
   return node;
 }
 
-mppi::Optimizer getDummyOptimizer(auto node, auto costmap_ros, auto * params_handler)
+std::shared_ptr<mppi::Optimizer> getDummyOptimizer(auto node, auto costmap_ros, auto * params_handler)
 {
-  auto optimizer = mppi::Optimizer();
+  std::shared_ptr<mppi::Optimizer> optimizer = std::make_shared<mppi::Optimizer>();
   std::weak_ptr<rclcpp_lifecycle::LifecycleNode> weak_ptr_node{node};
 
-  optimizer.initialize(weak_ptr_node, node->get_name(), costmap_ros, params_handler);
+  optimizer->initialize(weak_ptr_node, node->get_name(), costmap_ros, params_handler);
 
   return optimizer;
 }
@@ -145,7 +145,7 @@ mppi::PathHandler getDummyPathHandler(
   auto node, auto costmap_ros, auto tf_buffer,
   auto * params_handler)
 {
-  auto path_handler = mppi::PathHandler();
+  mppi::PathHandler path_handler;
   std::weak_ptr<rclcpp_lifecycle::LifecycleNode> weak_ptr_node{node};
 
   path_handler.initialize(weak_ptr_node, node->get_name(), costmap_ros, tf_buffer, params_handler);
@@ -153,13 +153,13 @@ mppi::PathHandler getDummyPathHandler(
   return path_handler;
 }
 
-mppi::Controller getDummyController(auto node, auto tf_buffer, auto costmap_ros)
+std::shared_ptr<mppi::Controller> getDummyController(auto node, auto tf_buffer, auto costmap_ros)
 {
-  auto controller = mppi::Controller();
+  std::shared_ptr<mppi::Controller> controller = std::make_shared<mppi::Controller>();
   std::weak_ptr<rclcpp_lifecycle::LifecycleNode> weak_ptr_node{node};
 
-  controller.configure(weak_ptr_node, node->get_name(), tf_buffer, costmap_ros);
-  controller.activate();
+  controller->configure(weak_ptr_node, node->get_name(), tf_buffer, costmap_ros);
+  controller->activate();
   return controller;
 }
 


### PR DESCRIPTION
Partially to clean things up but also compiling with some of these flags seems to help and are the same compiler flags as used in https://romanpoya.medium.com/a-look-at-the-performance-of-expression-templates-in-c-eigen-vs-blaze-vs-fastor-vs-armadillo-vs-2474ed38d982 for comparison eith eigen/xtensor/fastor/etc more or less just assuming they know what they're doing. 

While the system gets into the 20s of ms, it spends more time in the teens, so I think it has incremental help. I didn't do formal benchmarking, but its clear from the stream of values coming back to me that these flags improved things. 

I haven't looked into it yet, but most of the time that we miss our loop rate, its due to 1 really odd cycle that is high. I suspect that's due to the path handler, so that might be an area to consider for optimization.  