### PR TITLE
normalizing trajectory angles

### DIFF
--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -259,7 +259,7 @@ void Optimizer::integrateStateVelocities(
 
   auto & w = state.wz;
   double initial_yaw = tf2::getYaw(state_.pose.pose.orientation);
-  yaw = xt::cumsum(w * settings_.model_dt, 1) + initial_yaw;
+  yaw = utils::normalize_angles(xt::cumsum(w * settings_.model_dt, 1) + initial_yaw);
   xt::xtensor<float, 2> yaw_offseted = yaw;
 
   xt::view(yaw_offseted, xt::all(), xt::range(1, _)) =


### PR DESCRIPTION
There is no appreciable change in performance and makes sure in the future all user-generated critics can assume properly normalized trajectory orientations