### PR TITLE
Optimizations: Part 4

### DIFF
--- a/include/mppic/models/state.hpp
+++ b/include/mppic/models/state.hpp
@@ -20,8 +20,6 @@ struct State
   xt::xtensor<float, 2> cvy;
   xt::xtensor<float, 2> cwz;
 
-  xt::xtensor<float, 2> dt;
-
   geometry_msgs::msg::PoseStamped pose;
   geometry_msgs::msg::Twist speed;
 
@@ -34,8 +32,6 @@ struct State
     cvx = xt::zeros<float>({batch_size, time_steps});
     cvy = xt::zeros<float>({batch_size, time_steps});
     cwz = xt::zeros<float>({batch_size, time_steps});
-
-    dt = xt::zeros<float>({batch_size, time_steps});
   }
 
 };

--- a/include/mppic/models/state.hpp
+++ b/include/mppic/models/state.hpp
@@ -33,7 +33,6 @@ struct State
     cvy = xt::zeros<float>({batch_size, time_steps});
     cwz = xt::zeros<float>({batch_size, time_steps});
   }
-
 };
 
 }

--- a/include/mppic/tools/utils.hpp
+++ b/include/mppic/tools/utils.hpp
@@ -98,7 +98,6 @@ inline bool withinPositionGoalTolerance(
   return false;
 }
 
-
 /**
   * @brief normalize
   *
@@ -112,7 +111,6 @@ auto normalize_angles(const T & angles)
   auto theta = xt::eval(xt::fmod(angles + M_PI, 2.0 * M_PI));
   return xt::eval(xt::where(theta <= 0.0, theta + M_PI, theta - M_PI));
 }
-
 
 /**
   * @brief shortest_angular_distance

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -68,9 +68,7 @@ geometry_msgs::msg::TwistStamped Controller::computeVelocityCommands(
     optimizer_.evalControl(robot_pose, robot_speed, transformed_plan, goal_checker);
 
   auto end = std::chrono::system_clock::now();
-
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-
   RCLCPP_INFO(logger_, "Control loop execution time: %ld [ms]", duration);
 
   if (visualize_) {

--- a/src/critics/path_align_critic.cpp
+++ b/src/critics/path_align_critic.cpp
@@ -44,7 +44,7 @@ void PathAlignCritic::score(CriticData & data)
   auto cost = xt::xtensor<float, 1>::from_shape({trajectories_count});
 
   xt::xtensor<float, 2> P2_P1_diff = P2 - P1;
-  xt::xtensor<float, 1> P2_P1_norm_sq = xt::eval(xt::norm_sq(P2_P1_diff, {1}));
+  xt::xtensor<float, 1> P2_P1_norm_sq = xt::norm_sq(P2_P1_diff, {1});
 
   auto evaluate_u = [&P1, &P3, &P2_P1_diff, &P2_P1_norm_sq](
     size_t t, size_t p, size_t s) {

--- a/src/critics/path_align_critic.cpp
+++ b/src/critics/path_align_critic.cpp
@@ -44,7 +44,7 @@ void PathAlignCritic::score(CriticData & data)
   auto cost = xt::xtensor<float, 1>::from_shape({trajectories_count});
 
   xt::xtensor<float, 2> P2_P1_diff = P2 - P1;
-  xt::xtensor<float, 1> P2_P1_norm_sq = xt::norm_sq(P2_P1_diff, {1});
+  xt::xtensor<float, 1> P2_P1_norm_sq = xt::eval(xt::norm_sq(P2_P1_diff, {1}));
 
   auto evaluate_u = [&P1, &P3, &P2_P1_diff, &P2_P1_norm_sq](
     size_t t, size_t p, size_t s) {
@@ -66,10 +66,10 @@ void PathAlignCritic::score(CriticData & data)
   {
     auto next = xt::view(P3, xt::all(), xt::range(1, _), xt::range(0, 2));
     auto prev = xt::view(P3, xt::all(), xt::range(_, -1), xt::range(0, 2));
-    auto dist = xt::norm_sq(next - prev, {2});
-    trajectories_lengths = xt::sum(dist, {1});
+    auto dist = xt::eval(xt::norm_sq(next - prev, {2}));
+    trajectories_lengths = xt::sum(dist, {1}, xt::evaluation_strategy::immediate);
   }
-  auto accumulated_path_distances = xt::cumsum(P2_P1_norm_sq);
+  auto accumulated_path_distances = xt::eval(xt::cumsum(P2_P1_norm_sq));
 
   size_t max_s = 0;
   for (size_t t = 0; t < trajectories_count; ++t) {

--- a/src/critics/prefer_forward_critic.cpp
+++ b/src/critics/prefer_forward_critic.cpp
@@ -16,8 +16,6 @@ void PreferForwardCritic::initialize()
     logger_, "PreferForwardCritic instantiated with %d power and %f weight.", power_, weight_);
 }
 
-inline auto approx_atan2 = xt::vectorize(atan2_approx);
-
 void PreferForwardCritic::score(CriticData & data)
 {
   if (!enabled_) {

--- a/src/critics/prefer_forward_critic.cpp
+++ b/src/critics/prefer_forward_critic.cpp
@@ -1,6 +1,7 @@
 // Copyright 2022 @artofnothingness Alexey Budyakov, Samsung Research
 
 #include "mppic/critics/prefer_forward_critic.hpp"
+#include <xtensor/xvectorize.hpp>
 
 namespace mppi::critics
 {
@@ -15,6 +16,45 @@ void PreferForwardCritic::initialize()
     logger_, "PreferForwardCritic instantiated with %d power and %f weight.", power_, weight_);
 }
 
+// Derivative of https://gist.github.com/volkansalma/2972237
+#define PI_FLOAT     3.14159265f
+#define PIBY2_FLOAT  1.5707963f
+// |error| < 0.005
+float atan2_approx(float y, float x)
+{
+  if (x == 0.0f) {
+    if (y > 0.0f) {
+      return PIBY2_FLOAT;
+    }
+    if (y == 0.0f) {
+      return 0.0f;
+    }
+    return -PIBY2_FLOAT;
+  }
+
+  float atan;
+  float z = y / x;
+
+  if (fabs(z) < 1.0f ) {
+    atan = z / (1.0f + 0.28f * z * z);
+    if (x < 0.0f) {
+      if (y < 0.0f) {
+        return atan - PI_FLOAT;
+      }
+      return atan + PI_FLOAT;
+    }
+  } else {
+    atan = PIBY2_FLOAT - z / (z * z + 0.28f);
+    if (y < 0.0f) {
+      return atan - PI_FLOAT;
+    }
+  }
+
+  return atan;
+}
+
+inline auto approx_atan2 = xt::vectorize(atan2_approx);
+
 void PreferForwardCritic::score(CriticData & data)
 {
   if (!enabled_) {
@@ -27,15 +67,17 @@ void PreferForwardCritic::score(CriticData & data)
     xt::view(data.trajectories, xt::all(), xt::range(_, -1), 0);
   auto dy = xt::view(data.trajectories, xt::all(), xt::range(1, _), 1) -
     xt::view(data.trajectories, xt::all(), xt::range(_, -1), 1);
-
-  auto thetas = xt::atan2(dy, dx);
+  
+  auto thetas = approx_atan2(dy, dx);  // Speeds up
   auto yaws = xt::view(data.trajectories, xt::all(), xt::range(_, -1), 2);
 
-  auto yaws_local = xt::abs(utils::shortest_angular_distance(thetas, yaws));
+  auto yaws_local = thetas - yaws;
+
   auto forward_translation_reversed = -xt::cos(yaws_local) * xt::hypot(dx, dy);
+  
   auto backward_translation = xt::maximum(forward_translation_reversed, 0);
 
-  data.costs += xt::pow(xt::sum(backward_translation, {1}) * weight_, power_);
+  data.costs += xt::pow(xt::sum(backward_translation, {1}, xt::evaluation_strategy::immediate) * weight_, power_);
 }
 }  // namespace mppi::critics
 

--- a/src/critics/prefer_forward_critic.cpp
+++ b/src/critics/prefer_forward_critic.cpp
@@ -1,7 +1,6 @@
 // Copyright 2022 @artofnothingness Alexey Budyakov, Samsung Research
 
 #include "mppic/critics/prefer_forward_critic.hpp"
-#include <xtensor/xvectorize.hpp>
 
 namespace mppi::critics
 {

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -101,7 +101,6 @@ void Optimizer::setOffset(double controller_frequency)
 void Optimizer::reset()
 {
   state_.reset(settings_.batch_size, settings_.time_steps);
-  state_.dt.fill(settings_.model_dt);
   control_sequence_.reset(settings_.time_steps);
 
   costs_ = xt::zeros<float>({settings_.batch_size});
@@ -294,8 +293,6 @@ xt::xtensor<float, 2> Optimizer::getOptimizedTrajectory()
   if (isHolonomic()) {
     xt::view(state.cvy, 0, xt::all()) = control_sequence_.vy;
   }
-
-  state.dt.fill(settings_.model_dt);
 
   updateStateVelocities(state);
 


### PR DESCRIPTION
Moving `sum` to `immediate` speeds things up quite a bit, which various documentation on xtensor also shows. 

Evaling on the path align critic also helps uniquely to that critic, I suspect because of the manual looping calls only some of the values and computed at-time so it doesn't get to use vectorization optimizations.

The approximate atan2 also helps lower the runtime of the `atan2` operation by about 2x steady state and its contribution to jitter. I see you have a PR implementing it differently, which I'll test, but this does not change the existing behavior and improves things quite a bit. There's still contribution to jitter, but usually on the order of 2-4ms where before it could get upwards of 6-10 (the rest is probably the cosine or hypot). Doesn't help with any other sources of jitter. Incremental progress. 

Removed `dt`, as it is never used or referenced 