### PR TITLE
adding threshold to consider to other critics to disable on approach to goal + retune a little

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,14 @@ sudo make install
  | ---------------                  | ------ | ----------------------------------------------------------------------------------------------------------- |
  | goal_angle_cost_weight           | double |                                                                                                             |
  | goal_angle_cost_power            | int    |                                                                                                             |
- | threshold_to_consider_goal_angle | double | Minimal distance between robot and goal above which angle goal cost considered                              |
+ | threshold_to_consider            | double | Minimal distance between robot and goal above which angle goal cost considered                              |
 
 #### PathAngleCritic params
  | Parameter                 | Type   | Definition                                                                                                  |
  | ---------------           | ------ | ----------------------------------------------------------------------------------------------------------- |
  | path_angle_cost_weight    | double |                                                                                                             |
  | path_angle_cost_power     | int    |                                                                                                             |
+ | threshold_to_consider            | double | Distance between robot and goal above which path angle cost stops being considered                              |
 
 #### PathAlignCritic params
  | Parameter                  | Type   | Definition                                                                                                              |
@@ -107,6 +108,7 @@ sudo make install
  | enable_nearest_goal_critic | bool   | enable critic that scores by mean distance from generated trajectories to nearest to generated trajectories path points |
  | path_point_step            | int    | Consider path points with given step                                                                                    |
  | trajectory_point_step      | int    | Consider generated trajectories points with given step                                                                  |
+ | threshold_to_consider            | double | Distance between robot and goal above which path align cost stops being considered                              |
 
 
 #### ObstaclesCritic params
@@ -121,6 +123,7 @@ sudo make install
  | ---------------       | ------ | ----------------------------------------------------------------------------------------------------------- |
  | prefer_forward_cost_weight | double |                                                                                                             |
  | prefer_forward_cost_power  | int    |                                                                                                             |
+ | threshold_to_consider            | double | Distance between robot and goal above which prefer forward cost stops being considered                              |
 
 #### TwirlingCritic params
  | Parameter             | Type   | Definition                                                                                                  |
@@ -165,7 +168,7 @@ controller_server:
         enabled: true
         cost_power: 1
         cost_weight: 3.0
-        threshold_to_consider_goal_angle: 0.35
+        threshold_to_consider: 0.4
       ObstaclesCritic:
         enabled: true
         cost_power: 2
@@ -178,6 +181,7 @@ controller_server:
         cost_weight: 2.0
         path_point_step: 2
         trajectory_point_step: 3
+        threshold_to_consider: 0.40
       PathFollowCritic:
         enabled: true
         cost_power: 1
@@ -189,10 +193,12 @@ controller_server:
         cost_power: 1
         cost_weight: 2.0
         offset_from_furthest: 4
+        threshold_to_consider: 0.40
       PreferForwardCritic:
         enabled: true
         cost_power: 1
         cost_weight: 3.0
+        threshold_to_consider: 0.4
       # TwirlingCritic:
       #   twirling_cost_power: 1
       #   twirling_cost_weight: 10.0

--- a/include/mppic/critics/goal_angle_critic.hpp
+++ b/include/mppic/critics/goal_angle_critic.hpp
@@ -22,7 +22,7 @@ public:
   void score(CriticData & data) override;
 
 protected:
-  float threshold_to_consider_goal_angle_{0};
+  float threshold_to_consider_{0};
   unsigned int power_{0};
   float weight_{0};
 };

--- a/include/mppic/critics/path_align_critic.hpp
+++ b/include/mppic/critics/path_align_critic.hpp
@@ -23,6 +23,7 @@ public:
 protected:
   unsigned int path_point_step_{0};
   unsigned int trajectory_point_step_{0};
+  float threshold_to_consider_{0};
 
   unsigned int power_{0};
   float weight_{0};

--- a/include/mppic/critics/path_angle_critic.hpp
+++ b/include/mppic/critics/path_angle_critic.hpp
@@ -21,6 +21,7 @@ public:
 
 protected:
   double max_angle_to_furthest_{0};
+  float threshold_to_consider_{0};
 
   size_t offset_from_furthest_{0};
 

--- a/include/mppic/critics/prefer_forward_critic.hpp
+++ b/include/mppic/critics/prefer_forward_critic.hpp
@@ -18,6 +18,7 @@ public:
 protected:
   unsigned int power_{0};
   float weight_{0};
+  float threshold_to_consider_{0};
 };
 
 }  // namespace mppi::critics

--- a/include/mppic/tools/utils.hpp
+++ b/include/mppic/tools/utils.hpp
@@ -104,7 +104,7 @@ inline bool withinPositionGoalTolerance(
   const geometry_msgs::msg::Pose & robot,
   const models::Path & path)
 {
-  const auto goal_idx = path.x.shape(0);
+  const auto goal_idx = path.x.shape(0) - 1;
   const auto goal_x = path.x(goal_idx);
   const auto goal_y = path.y(goal_idx);
 

--- a/include/mppic/tools/utils.hpp
+++ b/include/mppic/tools/utils.hpp
@@ -99,6 +99,29 @@ inline bool withinPositionGoalTolerance(
   return false;
 }
 
+inline bool withinPositionGoalTolerance(
+  const float & pose_tolerance,
+  const geometry_msgs::msg::Pose & robot,
+  const models::Path & path)
+{
+  const auto goal_idx = path.x.shape(0);
+  const auto goal_x = path.x(goal_idx);
+  const auto goal_y = path.y(goal_idx);
+
+  const auto pose_tolerance_sq = pose_tolerance * pose_tolerance;
+
+  auto dx = robot.position.x - goal_x;
+  auto dy = robot.position.y - goal_y;
+
+  auto dist_sq = dx * dx + dy * dy;
+
+  if (dist_sq < pose_tolerance_sq) {
+    return true;
+  }
+
+  return false;
+}
+
 /**
   * @brief normalize
   *

--- a/include/mppic/tools/utils.hpp
+++ b/include/mppic/tools/utils.hpp
@@ -75,7 +75,7 @@ inline bool withinPositionGoalTolerance(
   const geometry_msgs::msg::Pose & robot,
   const models::Path & path)
 {
-  const auto goal_idx = path.x.shape(0);
+  const auto goal_idx = path.x.shape(0) - 1;
   const auto goal_x = path.x(goal_idx);
   const auto goal_y = path.y(goal_idx);
 

--- a/include/mppic/tools/utils.hpp
+++ b/include/mppic/tools/utils.hpp
@@ -100,7 +100,7 @@ inline bool withinPositionGoalTolerance(
 }
 
 inline bool withinPositionGoalTolerance(
-  const float & pose_tolerance,
+  float tolerance,
   const geometry_msgs::msg::Pose & robot,
   const models::Path & path)
 {

--- a/src/critics/goal_angle_critic.cpp
+++ b/src/critics/goal_angle_critic.cpp
@@ -11,13 +11,13 @@ void GoalAngleCritic::initialize()
   getParam(power_, "cost_power", 1);
   getParam(weight_, "cost_weight", 3.0);
 
-  getParam(threshold_to_consider_goal_angle_, "threshold_to_consider_goal_angle", 0.35);
+  getParam(threshold_to_consider_, "threshold_to_consider", 0.40);
 
   RCLCPP_INFO(
     logger_,
     "GoalAngleCritic instantiated with %d power, %f weight, and %f "
     "angular threshold.",
-    power_, weight_, threshold_to_consider_goal_angle_);
+    power_, weight_, threshold_to_consider_);
 }
 
 void GoalAngleCritic::score(CriticData & data)
@@ -36,7 +36,7 @@ void GoalAngleCritic::score(CriticData & data)
 
   const auto dist = std::sqrt(dx * dx + dy * dy);
 
-  if (dist < threshold_to_consider_goal_angle_) {
+  if (dist < threshold_to_consider_) {
     const auto goal_yaw = data.path.yaws(goal_idx);
 
     data.costs += xt::pow(

--- a/src/critics/path_align_critic.cpp
+++ b/src/critics/path_align_critic.cpp
@@ -15,6 +15,9 @@ void PathAlignCritic::initialize()
 
   getParam(path_point_step_, "path_point_step", 2);
   getParam(trajectory_point_step_, "trajectory_point_step", 3);
+  getParam(
+    threshold_to_consider_,
+    "threshold_to_consider", 0.40f);
 
   RCLCPP_INFO(
     logger_,
@@ -24,8 +27,8 @@ void PathAlignCritic::initialize()
 
 void PathAlignCritic::score(CriticData & data)
 {
-  if (!enabled_ ||
-    utils::withinPositionGoalTolerance(data.goal_checker, data.state.pose.pose, data.path))
+  utils::setPathFurthestPointIfNotSet(data);
+  if (!enabled_ || utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path))
   {
     return;
   }

--- a/src/critics/path_angle_critic.cpp
+++ b/src/critics/path_angle_critic.cpp
@@ -12,7 +12,9 @@ void PathAngleCritic::initialize()
   getParam(offset_from_furthest_, "offset_from_furthest", 4);
   getParam(power_, "cost_power", 1);
   getParam(weight_, "cost_weight", 2.0);
-
+  getParam(
+    threshold_to_consider_,
+    "threshold_to_consider", 0.40f);
   getParam(
     max_angle_to_furthest_,
     "max_angle_to_furthest", M_PI_2);
@@ -26,13 +28,12 @@ void PathAngleCritic::initialize()
 
 void PathAngleCritic::score(CriticData & data)
 {
-
   using xt::evaluation_strategy::immediate;
   if (!enabled_) {
     return;
   }
 
-  if (utils::withinPositionGoalTolerance(data.goal_checker, data.state.pose.pose, data.path)) {
+  if (utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path)) {
     return;
   }
 

--- a/src/critics/path_follow_critic.cpp
+++ b/src/critics/path_follow_critic.cpp
@@ -13,7 +13,7 @@ void PathFollowCritic::initialize()
 
   getParam(
     max_path_ratio_,
-    "max_path_ratio", 0.35f);
+    "max_path_ratio", 0.40f);
 
   getParam(offset_from_furthest_, "offset_from_furthest", 10);
 

--- a/src/critics/prefer_forward_critic.cpp
+++ b/src/critics/prefer_forward_critic.cpp
@@ -10,6 +10,9 @@ void PreferForwardCritic::initialize()
   auto getParam = parameters_handler_->getParamGetter(name_);
   getParam(power_, "cost_power", 1);
   getParam(weight_, "cost_weight", 3.0);
+  getParam(
+    threshold_to_consider_,
+    "threshold_to_consider", 0.40f);
 
   RCLCPP_INFO(
     logger_, "PreferForwardCritic instantiated with %d power and %f weight.", power_, weight_);
@@ -23,7 +26,7 @@ void PreferForwardCritic::score(CriticData & data)
     return;
   }
 
-  if (utils::withinPositionGoalTolerance(data.goal_checker, data.state.pose.pose, data.path)) {
+  if (utils::withinPositionGoalTolerance(threshold_to_consider_, data.state.pose.pose, data.path)) {
     return;
   }
 


### PR DESCRIPTION
In further response to #79 

This helps make sure that we disable the critics that can create local-minima near goals are disabled closer to the goal poses. Rather than setting it to the positional tolerance (which could be 0.1-0.3m), we decouple when we stop considering these critics from the actual positional tolerance itself so a larger window around goals can be incentivized to focus on the relevant critics (collision, goal, goal angle).

I found that this (and tuning some of the weights a little more, which I later realized were off because my files were outdated :laughing: ) to increase the convergence to goal to nearly every time and doing so in a more direct way with less confusion. 

Even after these changes #79 needs to stay open until we can do testing on hardware to make sure that these changes and the previous work by @artofnothingness is sufficient. 